### PR TITLE
fix: sync docs with code and add missing templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ templates/    # Template files embedded into the binary at compile time
 
 ```bash
 make check        # fmt-check + clippy + test (full CI locally)
-make lint         # cargo clippy
+make lint         # cargo fmt --check + clippy
 make test         # cargo test --workspace
 make fmt          # cargo fmt
 make build        # cargo build
@@ -38,6 +38,12 @@ make release      # cargo build --release
 | `/diagnose [error]` | Diagnose issues |
 | `/deps [check/update]` | Manage dependencies |
 | `/doc-audit` | Audit docs vs code |
+| `/issues SPEC-NNN` | Generate issues from Spec |
+| `/retro` | Session retrospective |
+| `/ci [PR#]` | Check CI status |
+| `/pr [title]` | Create pull request |
+| `/deploy` | Deploy |
+| `/sync-commands` | Sync slash commands |
 
 ## Extension Points
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ name = "harn-modules"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "console",
  "harn-core",
  "harn-templates",
 ]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ project/
 ├── harn.toml                     # Reproducible config
 ├── .claude/
 │   ├── settings.json             # Permissions + pre-commit hook
-│   └── commands/                 # 15 slash commands
+│   └── commands/                 # Slash commands
 ├── .cursor/rules                 # Cursor AI rules
 ├── .windsurfrules                # Windsurf AI rules
 ├── .github/workflows/            # CI/CD pipelines
@@ -86,7 +86,7 @@ project/
 | `ci` | CI/CD pipelines | github, gitlab, gitea |
 | `agent` | AI coding agent configs | claude, cursor, windsurf, cline, opencode |
 | `build` | Build orchestration | make, just, task |
-| `ide` | Editor configuration | vscode, zed, jetbrains |
+| `ide` | Editor configuration | vscode, zed (jetbrains, vim planned) |
 | `git` | Git config | .gitignore (language-aware) |
 | `docker` | Containerization | Dockerfile, Compose |
 | `env` | Environment management | .env.example |
@@ -143,7 +143,7 @@ harn generates language-aware Makefiles, .gitignore, linter configs, and CI work
 | Go | go targets | bin/ | .golangci.yml | golangci-lint |
 | TypeScript | npm/pnpm targets | node_modules/ | eslint + prettier | lint + tsc |
 | Dart/Flutter | flutter targets | .dart_tool/ | analysis_options | analyze |
-| Python | pip/uv targets | __pycache__/ | — | — |
+| Python | pip/uv targets | __pycache__/ | — | planned |
 
 ## Methodology
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -99,7 +99,7 @@ pub struct SddConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CiConfig {
-    /// CI platform: github, gitlab, codeberg
+    /// CI platform: github, gitlab, gitea (alias: codeberg)
     #[serde(default = "default_ci_provider")]
     pub provider: String,
 
@@ -200,7 +200,7 @@ impl Default for BuildConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IdeConfig {
-    /// Editors: vscode, jetbrains, vim, zed
+    /// Editors: vscode, zed (jetbrains, vim planned)
     #[serde(default = "default_editors")]
     pub editors: Vec<String>,
 }

--- a/crates/modules/Cargo.toml
+++ b/crates/modules/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 harn-core.workspace = true
 harn-templates.workspace = true
 anyhow.workspace = true
+console.workspace = true
 
 [lints]
 workspace = true

--- a/crates/modules/src/agent.rs
+++ b/crates/modules/src/agent.rs
@@ -30,11 +30,15 @@ impl Module for AgentModule {
 
     fn generate(&self, ctx: &mut ProjectContext) -> Result<Vec<String>> {
         let engine = TemplateEngine::new();
-        let vars = TemplateEngine::vars_from_context(ctx);
+        let mut vars = TemplateEngine::vars_from_context(ctx);
         let force = ctx.force;
         let mut created = Vec::new();
 
         let agent_config = ctx.config.modules.agent.clone().unwrap_or_default();
+
+        // Build slash commands table from configured commands
+        let slash_table = Self::build_slash_commands_table(&agent_config.commands);
+        vars.insert("slash_commands_table".into(), slash_table);
 
         // CLAUDE.md and AGENTS.md — always generated (universal context)
         for name in &["CLAUDE.md", "AGENTS.md"] {
@@ -170,6 +174,36 @@ impl AgentModule {
         }
 
         Ok(created)
+    }
+
+    fn build_slash_commands_table(commands: &[String]) -> String {
+        let descriptions: &[(&str, &str, &str)] = &[
+            ("ship", "/ship [msg]", "Lint + test + commit + push + PR"),
+            ("implement", "/implement SPEC-NNN", "Implement a spec"),
+            ("spec", "/spec create/list/advance", "Manage spec lifecycle"),
+            ("lint", "/lint [fix]", "Run linters"),
+            ("test", "/test [scope]", "Run tests"),
+            ("review", "/review [PR#]", "Code review"),
+            ("diagnose", "/diagnose [error]", "Diagnose issues"),
+            ("deps", "/deps [check/update]", "Manage dependencies"),
+            ("doc-audit", "/doc-audit", "Audit docs vs code"),
+            ("issues", "/issues SPEC-NNN", "Generate issues from Spec"),
+            ("retro", "/retro", "Session retrospective"),
+            ("ci", "/ci [PR#]", "Check CI status"),
+            ("pr", "/pr [title]", "Create pull request"),
+            ("deploy", "/deploy", "Deploy"),
+            ("sync-commands", "/sync-commands", "Sync slash commands"),
+        ];
+
+        let mut rows = Vec::new();
+        for cmd in commands {
+            if let Some((_, display, desc)) = descriptions.iter().find(|(id, _, _)| *id == cmd) {
+                rows.push(format!("| `{display}` | {desc} |"));
+            } else {
+                rows.push(format!("| `/{cmd}` | {cmd} |"));
+            }
+        }
+        rows.join("\n")
     }
 
     fn build_claude_settings(&self, ctx: &ProjectContext) -> String {

--- a/crates/modules/src/build.rs
+++ b/crates/modules/src/build.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use console::style;
 use harn_core::context::ProjectContext;
 use harn_core::module::{Module, ModuleId};
 use harn_templates::TemplateEngine;
@@ -59,8 +60,17 @@ impl Module for BuildModule {
         };
 
         let dst = ctx.path(output_file);
-        if engine.has_template(&src) && engine.render_to(&src, &vars, &dst, force)? {
-            created.push(output_file.into());
+        if engine.has_template(&src) {
+            if engine.render_to(&src, &vars, &dst, force)? {
+                created.push(output_file.into());
+            }
+        } else {
+            eprintln!(
+                "  {} No template for build tool '{}' (language: {}), skipping",
+                style("WARN").yellow(),
+                tool,
+                primary_lang
+            );
         }
 
         Ok(created)

--- a/crates/modules/src/ide.rs
+++ b/crates/modules/src/ide.rs
@@ -7,9 +7,9 @@ use harn_templates::TemplateEngine;
 ///
 /// Supports:
 /// - VS Code (.vscode/settings.json, extensions.json)
-/// - `JetBrains` (.idea/)
-/// - Vim/Neovim (.nvim.lua / .exrc)
 /// - Zed (.zed/settings.json)
+/// - `JetBrains` (.idea/) — planned
+/// - Vim/Neovim (.nvim.lua / .exrc) — planned
 pub struct IdeModule;
 
 impl Module for IdeModule {
@@ -22,7 +22,7 @@ impl Module for IdeModule {
     }
 
     fn description(&self) -> &str {
-        "Editor configs (VS Code, JetBrains, Vim, Zed)"
+        "Editor configs (VS Code, Zed; JetBrains, Vim planned)"
     }
 
     fn generate(&self, ctx: &mut ProjectContext) -> Result<Vec<String>> {
@@ -58,7 +58,13 @@ impl Module for IdeModule {
                         }
                     }
                 }
-                _ => {} // jetbrains, vim — extend later
+                other => {
+                    eprintln!(
+                        "  {} No template for editor '{}', skipping",
+                        console::style("WARN").yellow(),
+                        other
+                    );
+                }
             }
         }
 

--- a/crates/modules/tests/template_coverage.rs
+++ b/crates/modules/tests/template_coverage.rs
@@ -1,0 +1,86 @@
+use harn_templates::TemplateEngine;
+
+/// Verify that all build tool + language combinations have templates.
+#[test]
+fn build_templates_exist_for_all_tools() {
+    let engine = TemplateEngine::new();
+    let tools = ["make", "just", "task"];
+    let languages = ["rust", "go", "typescript", "dart", "generic"];
+
+    for tool in &tools {
+        for lang in &languages {
+            let path = format!("build/{tool}/{lang}");
+            assert!(engine.has_template(&path), "Missing build template: {path}");
+        }
+    }
+}
+
+/// Verify that all IDE editors with code paths have templates.
+#[test]
+fn ide_templates_exist_for_supported_editors() {
+    let engine = TemplateEngine::new();
+
+    // Editors that have match arms in ide.rs
+    let editors_with_code = [
+        (
+            "vscode",
+            vec!["ide/vscode/settings.json", "ide/vscode/extensions.json"],
+        ),
+        ("zed", vec!["ide/zed/settings.json"]),
+    ];
+
+    for (editor, templates) in &editors_with_code {
+        for path in templates {
+            assert!(
+                engine.has_template(path),
+                "Missing IDE template for {editor}: {path}"
+            );
+        }
+    }
+}
+
+/// Verify that all default slash commands have template files.
+#[test]
+fn command_templates_exist_for_all_defaults() {
+    let engine = TemplateEngine::new();
+    let default_commands = [
+        "ship",
+        "implement",
+        "spec",
+        "lint",
+        "test",
+        "review",
+        "diagnose",
+        "deps",
+        "issues",
+        "doc-audit",
+        "retro",
+        "sync-commands",
+        "ci",
+        "pr",
+        "deploy",
+    ];
+
+    for cmd in &default_commands {
+        let path = format!("agent/commands/{cmd}.md");
+        assert!(
+            engine.has_template(&path),
+            "Missing command template: {path}"
+        );
+    }
+}
+
+/// Verify that all CI providers have at least a ci.yml template.
+#[test]
+fn ci_templates_exist_for_all_providers() {
+    let engine = TemplateEngine::new();
+    let providers = ["github", "gitlab", "gitea"];
+
+    for provider in &providers {
+        let path = format!("ci/{provider}/ci.yml");
+        assert!(
+            engine.has_template(&path),
+            "Missing CI template for {provider}: {path}"
+        );
+    }
+}

--- a/templates/agent/CLAUDE.md
+++ b/templates/agent/CLAUDE.md
@@ -13,7 +13,6 @@ TODO: List key directories and files
 ## Commands
 
 ```bash
-make dev          # Start development
 make build        # Build project
 make test         # Run tests
 make lint         # Run linters
@@ -25,15 +24,7 @@ make clean        # Clean artifacts
 
 | Command | Purpose |
 |---------|---------|
-| `/ship [msg]` | Lint + test + commit + push + PR |
-| `/implement SPEC-NNN` | Implement a spec |
-| `/spec create/list/advance` | Manage spec lifecycle |
-| `/lint [fix]` | Run linters |
-| `/test [scope]` | Run tests |
-| `/review [PR#]` | Code review |
-| `/diagnose [error]` | Diagnose issues |
-| `/deps [check/update]` | Manage dependencies |
-| `/doc-audit` | Audit docs vs code |
+{{ slash_commands_table }}
 
 ## Coding Rules
 

--- a/templates/agent/commands/doc-audit.md
+++ b/templates/agent/commands/doc-audit.md
@@ -1,8 +1,10 @@
 Audit docs vs code consistency.
 
 Steps:
-1. Compare `docs/reference/api-conventions.md` with actual routes
-2. Compare `docs/reference/data-model.md` with schema/migrations
-3. Compare `docs/reference/types/` with source code types
-4. Verify spec registry consistency
-5. Report discrepancies table
+1. Compare `docs/reference/api-conventions.md` with actual routes (skip if no API server)
+2. Compare `docs/reference/data-model.md` with schema/migrations (skip if no database)
+3. Compare `docs/reference/types/` with source code types (skip if no types defined)
+4. Verify spec registry consistency (`docs/specs/_index.md` vs actual spec dirs)
+5. Compare CLAUDE.md slash commands table with `.claude/commands/` files
+6. Compare README feature claims with actual implementation
+7. Report discrepancies table

--- a/templates/build/just/dart
+++ b/templates/build/just/dart
@@ -1,0 +1,29 @@
+# {{ project_name }} - Unified Build
+
+# Run debug
+dev:
+    flutter run
+
+# Build release APK
+build:
+    flutter build apk --release
+
+# Run tests
+test:
+    flutter test
+
+# Analyze
+lint:
+    flutter analyze
+
+# Format
+fmt:
+    dart format lib/ test/
+
+# Code generation
+gen:
+    flutter pub run build_runner build --delete-conflicting-outputs
+
+# Clean
+clean:
+    flutter clean

--- a/templates/build/just/generic
+++ b/templates/build/just/generic
@@ -1,0 +1,26 @@
+# {{ project_name }} - Unified Build
+# Customize targets for your project.
+
+# Start development
+dev:
+    @echo "TODO: Configure dev command"
+
+# Build
+build:
+    @echo "TODO: Configure build command"
+
+# Test
+test:
+    @echo "TODO: Configure test command"
+
+# Lint
+lint:
+    @echo "TODO: Configure lint command"
+
+# Format
+fmt:
+    @echo "TODO: Configure fmt command"
+
+# Clean
+clean:
+    @echo "TODO: Configure clean command"

--- a/templates/build/just/go
+++ b/templates/build/just/go
@@ -1,0 +1,35 @@
+# {{ project_name }} - Unified Build
+
+binary := `basename $PWD`
+
+# Run with hot-reload
+dev:
+    air
+
+# Run server
+run:
+    go run ./cmd/server/
+
+# Build binary
+build:
+    go build -o bin/{{binary}} ./cmd/server/
+
+# Run tests
+test:
+    go test -v -race -coverprofile=coverage.out ./...
+
+# Lint
+lint:
+    golangci-lint run ./...
+
+# Format
+fmt:
+    gofmt -w .
+
+# Tidy modules
+tidy:
+    go mod tidy
+
+# Clean
+clean:
+    rm -rf bin/ coverage.out

--- a/templates/build/just/rust
+++ b/templates/build/just/rust
@@ -1,0 +1,34 @@
+# {{ project_name }} - Unified Build
+
+# Run dev server
+dev:
+    cargo run
+
+# Build release
+build:
+    cargo build --release
+
+# Type check
+check:
+    cargo check --workspace
+
+# Run tests
+test:
+    cargo test --workspace
+
+# Lint
+lint:
+    cargo fmt --check
+    cargo clippy --workspace --all-targets -- -D warnings
+
+# Format
+fmt:
+    cargo fmt
+
+# Security audit
+audit:
+    cargo audit
+
+# Clean
+clean:
+    cargo clean

--- a/templates/build/just/typescript
+++ b/templates/build/just/typescript
@@ -1,0 +1,30 @@
+# {{ project_name }} - Unified Build
+
+# Start dev server
+dev:
+    npm run dev
+
+# Build for production
+build:
+    npm run build
+
+# Run tests
+test:
+    npm run test
+
+# Lint + type check
+lint:
+    npm run lint
+    npx tsc --noEmit
+
+# Format
+fmt:
+    npx prettier --write "src/**/*.{ts,tsx,css}"
+
+# Install dependencies
+install:
+    npm install
+
+# Clean
+clean:
+    rm -rf dist/ node_modules/.cache

--- a/templates/build/task/dart
+++ b/templates/build/task/dart
@@ -1,0 +1,37 @@
+version: '3'
+
+tasks:
+  dev:
+    desc: Run debug
+    cmds:
+      - flutter run
+
+  build:
+    desc: Build release APK
+    cmds:
+      - flutter build apk --release
+
+  test:
+    desc: Run tests
+    cmds:
+      - flutter test
+
+  lint:
+    desc: Analyze
+    cmds:
+      - flutter analyze
+
+  fmt:
+    desc: Format
+    cmds:
+      - dart format lib/ test/
+
+  gen:
+    desc: Code generation
+    cmds:
+      - flutter pub run build_runner build --delete-conflicting-outputs
+
+  clean:
+    desc: Clean
+    cmds:
+      - flutter clean

--- a/templates/build/task/generic
+++ b/templates/build/task/generic
@@ -1,0 +1,32 @@
+version: '3'
+
+tasks:
+  dev:
+    desc: Start development
+    cmds:
+      - echo "TODO: Configure dev command"
+
+  build:
+    desc: Build
+    cmds:
+      - echo "TODO: Configure build command"
+
+  test:
+    desc: Test
+    cmds:
+      - echo "TODO: Configure test command"
+
+  lint:
+    desc: Lint
+    cmds:
+      - echo "TODO: Configure lint command"
+
+  fmt:
+    desc: Format
+    cmds:
+      - echo "TODO: Configure fmt command"
+
+  clean:
+    desc: Clean
+    cmds:
+      - echo "TODO: Configure clean command"

--- a/templates/build/task/go
+++ b/templates/build/task/go
@@ -1,0 +1,46 @@
+version: '3'
+
+vars:
+  BINARY:
+    sh: basename $PWD
+
+tasks:
+  dev:
+    desc: Run with hot-reload
+    cmds:
+      - air
+
+  run:
+    desc: Run server
+    cmds:
+      - go run ./cmd/server/
+
+  build:
+    desc: Build binary
+    cmds:
+      - go build -o bin/{{.BINARY}} ./cmd/server/
+
+  test:
+    desc: Run tests
+    cmds:
+      - go test -v -race -coverprofile=coverage.out ./...
+
+  lint:
+    desc: Lint
+    cmds:
+      - golangci-lint run ./...
+
+  fmt:
+    desc: Format
+    cmds:
+      - gofmt -w .
+
+  tidy:
+    desc: Tidy modules
+    cmds:
+      - go mod tidy
+
+  clean:
+    desc: Clean
+    cmds:
+      - rm -rf bin/ coverage.out

--- a/templates/build/task/rust
+++ b/templates/build/task/rust
@@ -1,0 +1,43 @@
+version: '3'
+
+tasks:
+  dev:
+    desc: Run dev server
+    cmds:
+      - cargo run
+
+  build:
+    desc: Build release
+    cmds:
+      - cargo build --release
+
+  check:
+    desc: Type check
+    cmds:
+      - cargo check --workspace
+
+  test:
+    desc: Run tests
+    cmds:
+      - cargo test --workspace
+
+  lint:
+    desc: Lint
+    cmds:
+      - cargo fmt --check
+      - cargo clippy --workspace --all-targets -- -D warnings
+
+  fmt:
+    desc: Format
+    cmds:
+      - cargo fmt
+
+  audit:
+    desc: Security audit
+    cmds:
+      - cargo audit
+
+  clean:
+    desc: Clean
+    cmds:
+      - cargo clean

--- a/templates/build/task/typescript
+++ b/templates/build/task/typescript
@@ -1,0 +1,38 @@
+version: '3'
+
+tasks:
+  dev:
+    desc: Start dev server
+    cmds:
+      - npm run dev
+
+  build:
+    desc: Build for production
+    cmds:
+      - npm run build
+
+  test:
+    desc: Run tests
+    cmds:
+      - npm run test
+
+  lint:
+    desc: Lint + type check
+    cmds:
+      - npm run lint
+      - npx tsc --noEmit
+
+  fmt:
+    desc: Format
+    cmds:
+      - npx prettier --write "src/**/*.{ts,tsx,css}"
+
+  install:
+    desc: Install dependencies
+    cmds:
+      - npm install
+
+  clean:
+    desc: Clean
+    cmds:
+      - rm -rf dist/ node_modules/.cache

--- a/templates/ide/zed/settings.json
+++ b/templates/ide/zed/settings.json
@@ -1,0 +1,11 @@
+{
+  "tab_size": 2,
+  "format_on_save": "on",
+  "remove_trailing_whitespace_on_save": true,
+  "ensure_final_newline_on_save": true,
+  "file_scan_exclusions": [
+    "**/.git",
+    "**/node_modules",
+    "**/target"
+  ]
+}


### PR DESCRIPTION
## Summary

- **Add missing templates**: just (5 langs), task (5 langs), zed IDE settings — closes the gap between documented and actual feature support
- **Dynamic slash commands**: CLAUDE.md template now generates the slash commands table from configured commands list, preventing future drift
- **Runtime warnings**: build and IDE modules now warn when a configured tool/editor has no template instead of silently skipping
- **Template coverage tests**: 4 integration tests assert that all code paths have corresponding templates (build tools, IDE editors, slash commands, CI providers)
- **Doc fixes**: accurate `make lint` description, all 15 slash commands listed, correct feature matrix in README, fixed config doc comments

## Test plan

- [x] `make check` passes (fmt + clippy + test)
- [x] 4 new template coverage tests all pass
- [x] No clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)