### PR TITLE
docs: add iterative feedback loop to SDD workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,10 +9,6 @@ docs/
 │   ├── _templates/          # PRD, TD, Research templates
 │   ├── active/              # Specs in progress
 │   └── completed/           # Shipped specs
-├── reference/               # Single Source of Truth (SSOT)
-│   ├── types/               # Type definitions
-│   ├── api-conventions.md   # API design standards
-│   └── data-model.md        # Database schema
 └── playbooks/               # How-to guides
 ```
 

--- a/docs/playbooks/coding-agent-workflow.md
+++ b/docs/playbooks/coding-agent-workflow.md
@@ -8,9 +8,27 @@ Core principle: **Read docs first, write code, update docs last.**
 1. Read spec + reference docs
 2. Implement (data -> logic -> API -> UI -> tests)
 3. Verify (make lint && make test)
-4. Update reference docs
-5. Ship (/ship)
+4. Evaluate results
+   - Code-level issue → fix and go to step 3
+   - Design-level issue → update spec, go to step 1
+   - All good → continue
+5. Update reference docs
+6. Ship (/ship)
 ```
+
+## When to Update Spec vs Fix in Code
+
+**Update the spec** when:
+- API shape or interface contract changes
+- A task needs to be added, removed, or restructured
+- Constraints or non-goals turn out to be wrong
+- Architectural assumptions are invalidated
+
+**Fix in code** when:
+- Bug in implementation logic
+- Test edge case not anticipated
+- Performance tuning
+- Linter / formatting issues
 
 ## Quality Checklist
 

--- a/docs/playbooks/create-new-spec.md
+++ b/docs/playbooks/create-new-spec.md
@@ -16,3 +16,12 @@
 | Draft | Being written |
 | Active | Implementation in progress |
 | Completed | Verified by tests |
+
+## Revising an Active Spec
+
+When implementation reveals a design issue:
+
+1. Update the relevant section in PRD or TD
+2. Add an entry to TD's Revision Log with date and reason
+3. Update Task Breakdown if tasks changed
+4. Continue implementation from the updated spec

--- a/docs/specs/_templates/technical-design.md
+++ b/docs/specs/_templates/technical-design.md
@@ -68,3 +68,9 @@ _New config fields, environment variables._
 - **Unit tests:** ...
 - **Integration tests:** ...
 - **Manual verification:** ...
+
+## Revision Log
+
+| Date | Section | Change | Reason |
+|------|---------|--------|--------|
+|      |         |        |        |

--- a/templates/sdd/playbooks/coding-agent-workflow.md
+++ b/templates/sdd/playbooks/coding-agent-workflow.md
@@ -8,9 +8,27 @@ Core principle: **Read docs first, write code, update docs last.**
 1. Read spec + reference docs
 2. Implement (data -> logic -> API -> UI -> tests)
 3. Verify (make lint && make test)
-4. Update reference docs
-5. Ship (/ship)
+4. Evaluate results
+   - Code-level issue → fix and go to step 3
+   - Design-level issue → update spec, go to step 1
+   - All good → continue
+5. Update reference docs
+6. Ship (/ship)
 ```
+
+## When to Update Spec vs Fix in Code
+
+**Update the spec** when:
+- API shape or interface contract changes
+- A task needs to be added, removed, or restructured
+- Constraints or non-goals turn out to be wrong
+- Architectural assumptions are invalidated
+
+**Fix in code** when:
+- Bug in implementation logic
+- Test edge case not anticipated
+- Performance tuning
+- Linter / formatting issues
 
 ## Quality Checklist
 

--- a/templates/sdd/playbooks/create-new-spec.md
+++ b/templates/sdd/playbooks/create-new-spec.md
@@ -16,3 +16,12 @@
 | Draft | Being written |
 | Active | Implementation in progress |
 | Completed | Verified by tests |
+
+## Revising an Active Spec
+
+When implementation reveals a design issue:
+
+1. Update the relevant section in PRD or TD
+2. Add an entry to TD's Revision Log with date and reason
+3. Update Task Breakdown if tasks changed
+4. Continue implementation from the updated spec

--- a/templates/sdd/specs/_templates/technical-design.md
+++ b/templates/sdd/specs/_templates/technical-design.md
@@ -68,3 +68,9 @@ _New config fields, environment variables._
 - **Unit tests:** ...
 - **Integration tests:** ...
 - **Manual verification:** ...
+
+## Revision Log
+
+| Date | Section | Change | Reason |
+|------|---------|--------|--------|
+|      |         |        |        |


### PR DESCRIPTION
## Summary

- Add **Evaluate** step to coding-agent-workflow with feedback branches (code-level → re-verify, design-level → update spec)
- Add **"When to Update Spec vs Fix in Code"** decision criteria
- Add **Revision Log** table to TD template for tracking design changes during implementation
- Add **"Revising an Active Spec"** section to create-new-spec playbook
- Remove nonexistent `docs/reference/` from docs/README.md (caught by doc-audit)

All changes synced across `docs/` and `templates/sdd/`.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (4 tests, including template coverage)
- [x] doc-audit verified docs/ and templates/ are in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)