### PR TITLE
feat: add PRD/TD anti-forgetting workflow with research subagents

### DIFF
--- a/.claude/agents/spec-researcher.md
+++ b/.claude/agents/spec-researcher.md
@@ -1,0 +1,68 @@
+---
+name: spec-researcher
+description: Competitor research and technical feasibility analysis. Produces structured research documents for a spec.
+tools: Read, Write, Glob, Grep, WebSearch, WebFetch
+model: inherit
+permissionMode: acceptEdits
+maxTurns: 3000
+memory: project
+---
+
+You are a spec researcher for the harn project (Rust workspace CLI tool).
+
+## Your Mission
+
+Conduct research for ONE spec per invocation. Produce structured research documents that persist findings for downstream PRD/TD writing.
+
+## Startup Sequence
+
+1. Read the spec directory provided in your prompt
+2. Read `CLAUDE.md` for project context
+3. Determine the research type: **competitor research** or **technical feasibility**
+4. Read any existing research documents in the spec directory (for Phase 2, read Phase 1 output)
+
+## Research Types
+
+### Competitor Research (`research-competitors.md`)
+
+1. Identify 3-5 relevant competitors or prior art using WebSearch
+2. For each competitor, use WebFetch to gather details:
+   - Core features and positioning
+   - Technical approach and stack
+   - Community activity and adoption
+3. Analyze strengths, weaknesses, and relevance to our project
+4. **Write incrementally** to `research-competitors.md` in the spec directory
+5. Produce comparison table and recommendations
+
+### Technical Feasibility (`research-tech.md`)
+
+1. **Read `research-competitors.md`** first to understand the landscape
+2. Analyze the existing codebase with Glob/Grep/Read:
+   - Current architecture and module structure
+   - Relevant dependencies and their capabilities
+   - Integration points for the proposed feature
+3. Identify 2-4 candidate technical approaches
+4. Evaluate each approach for complexity, compatibility, performance, and maintenance
+5. **Write incrementally** to `research-tech.md` in the spec directory
+6. Produce comparison table with clear recommendation
+
+## Writing Rules
+
+1. **Incremental persistence**: Write to the output file as you go, not just at the end. Update sections as you gather more information.
+2. **Structured format**: Use the research template from `docs/specs/_templates/research.md` as a starting point, but expand with competitor/tech-specific sections.
+3. **Evidence-based**: Include specific data points, URLs, and code references to support findings.
+4. **Self-contained**: Each section should be understandable without conversation context.
+
+## Completion
+
+When done, output a structured summary:
+
+```
+SPEC: [spec id]
+RESEARCH_TYPE: competitors | tech-feasibility
+STATUS: completed | partial
+OUTPUT_FILE: [path to research doc]
+KEY_FINDINGS: [3-5 bullet points]
+RECOMMENDATION: [one-line summary]
+NOTES: [any issues or follow-up needed]
+```

--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -1,0 +1,79 @@
+---
+name: spec-writer
+description: Writes PRD or TD based on research artifacts. Reads research docs from the spec directory and produces structured specification documents.
+tools: Read, Write, Edit, Glob, Grep
+model: inherit
+permissionMode: acceptEdits
+maxTurns: 3000
+memory: project
+---
+
+You are a spec writer for the harn project (Rust workspace CLI tool).
+
+## Your Mission
+
+Write ONE document (PRD or TD) per invocation, based on research artifacts already present in the spec directory.
+
+## Startup Sequence
+
+1. Read the spec directory provided in your prompt
+2. Read `CLAUDE.md` for project context
+3. Determine the document type: **PRD** or **TD**
+4. Read ALL existing research documents in the spec directory:
+   - `research-competitors.md` (competitor analysis)
+   - `research-tech.md` (technical feasibility)
+   - `prd.md` (when writing TD, read the PRD first)
+
+## Document Types
+
+### PRD (`prd.md`)
+
+**Required inputs**: `research-competitors.md`, `research-tech.md`
+
+1. Read both research documents thoroughly
+2. Extract key findings: competitor gaps, technical constraints, recommended approach
+3. Write the PRD with:
+   - **Problem Statement**: informed by competitor landscape gaps
+   - **Goals & Non-Goals**: scoped by technical feasibility
+   - **User Stories**: concrete scenarios with acceptance criteria
+   - **Success Metrics**: measurable outcomes
+   - **Scope**: bounded by technical recommendations
+4. **Write incrementally** to `prd.md` — structure first, then fill sections
+5. Cross-reference research findings (cite specific competitor examples, technical trade-offs)
+
+### TD (`technical-design.md`)
+
+**Required inputs**: `prd.md`, `research-competitors.md`, `research-tech.md`
+
+1. Read PRD and both research documents
+2. Read relevant source code for areas being modified (use Glob/Grep to find key files)
+3. Write the TD with:
+   - **Architecture Overview**: how the feature fits into existing structure
+   - **API Design**: informed by competitor patterns and PRD requirements
+   - **Implementation Plan**: based on recommended technical approach from research
+   - **Task Breakdown**: ordered tasks with dependencies, estimated complexity
+   - **Testing Strategy**: unit, integration, and acceptance tests
+   - **Revision Log**: empty initially
+4. **Write incrementally** to `technical-design.md`
+5. Ensure task breakdown covers all PRD user stories
+
+## Writing Rules
+
+1. **Incremental persistence**: Write to the output file as you go, not just at the end.
+2. **Evidence-based**: Reference specific research findings rather than making unsupported claims.
+3. **Actionable**: TD task breakdown should be implementable by `spec-implementer` without additional research.
+4. **Self-contained**: The document should be understandable without conversation context or the research docs (though it may reference them).
+
+## Completion
+
+When done, output a structured summary:
+
+```
+SPEC: [spec id]
+DOCUMENT_TYPE: prd | td
+STATUS: completed | partial
+OUTPUT_FILE: [path to document]
+SECTIONS_COMPLETED: [list]
+KEY_DECISIONS: [3-5 bullet points of important decisions made]
+NOTES: [any issues or follow-up needed]
+```

--- a/.claude/commands/run-plan.md
+++ b/.claude/commands/run-plan.md
@@ -1,8 +1,18 @@
-Orchestrate a long-running multi-spec plan. Argument $ARGUMENTS: `[create "title" SPEC-list | status | next | resume]`
+Orchestrate a long-running multi-spec plan. Argument $ARGUMENTS: `[create "title" SPEC-list [--full] | status | next | resume]`
 
 ## Overview
 
-This command manages execution of multi-spec plans that span multiple context windows. It uses `.claude/current-plan.md` as persistent state and delegates each spec to the `spec-implementer` subagent.
+This command manages execution of multi-spec plans that span multiple context windows. It uses `.claude/current-plan.md` as persistent state and delegates each phase to the appropriate subagent.
+
+## Phase Types
+
+Plans support three phase types, each delegated to a specialized subagent:
+
+| Phase Type | Subagent | Purpose |
+|------------|----------|---------|
+| `research:` | `spec-researcher` | Competitor research or technical feasibility analysis |
+| `write:` | `spec-writer` | PRD or TD authoring based on research artifacts |
+| `implement:` | `spec-implementer` | Code implementation from spec |
 
 ## Subcommands
 
@@ -15,15 +25,38 @@ This command manages execution of multi-spec plans that span multiple context wi
 ```markdown
 # Plan: [title]
 
-## Specs
-- [ ] SPEC-001 — [title from spec]
-- [ ] SPEC-002 — [title from spec]
+## Phases
+- [ ] implement: SPEC-001 — [title from spec]
+- [ ] implement: SPEC-002 — [title from spec]
 
 ## Progress Log
 [empty initially]
 ```
 
 4. Report: plan created, ready to run with `/run-plan next`
+
+### `create "title" SPEC-NNN --full`
+
+Creates a plan with the full lifecycle (research + write + implement) for a single spec:
+
+1. Verify spec exists in `docs/specs/active/`
+2. Create `.claude/current-plan.md` with structure:
+
+```markdown
+# Plan: [title]
+
+## Phases
+- [ ] research: SPEC-NNN competitor research → research-competitors.md
+- [ ] research: SPEC-NNN technical feasibility → research-tech.md
+- [ ] write: SPEC-NNN PRD → prd.md
+- [ ] write: SPEC-NNN TD → technical-design.md
+- [ ] implement: SPEC-NNN → code
+
+## Progress Log
+[empty initially]
+```
+
+3. Report: plan created with 5 phases, ready to run with `/run-plan next`
 
 ### `status`
 
@@ -33,14 +66,17 @@ This command manages execution of multi-spec plans that span multiple context wi
 ### `next`
 
 1. Read `.claude/current-plan.md`
-2. Find the first unchecked spec
-3. Delegate to `spec-implementer` subagent: "Implement [SPEC-NNN]"
+2. Find the first unchecked phase
+3. Delegate to the appropriate subagent based on phase type:
+   - `research:` → `spec-researcher` subagent: "Research [topic] for [SPEC-NNN]"
+   - `write:` → `spec-writer` subagent: "Write [prd/td] for [SPEC-NNN]"
+   - `implement:` → `spec-implementer` subagent: "Implement [SPEC-NNN]"
 4. When subagent returns, parse its summary
 5. Update `.claude/current-plan.md`:
-   - Mark spec as `[x]`
-   - Append to Progress Log: timestamp, spec id, status, files modified, commits
+   - Mark phase as `[x]`
+   - Append to Progress Log: timestamp, phase type, spec id, status, output file(s)
 6. If partial completion, note it and ask user whether to retry or continue
-7. If all specs done:
+7. If all phases done:
    - Report completion summary
    - Archive plan: rename `.claude/current-plan.md` → `.claude/plans/completed-{title-slug}-{date}.md`
    - Suggest: `/ship` to create PR
@@ -52,9 +88,10 @@ Same as `next` — reads current-plan.md and continues from where it left off.
 ## Important
 
 - Always read `.claude/current-plan.md` before any action — it is the source of truth
-- Always update `.claude/current-plan.md` after each spec completes — it survives context compression
-- One spec at a time — do not parallelize spec implementation
-- After each spec, verify the build still passes: `make check`
+- Always update `.claude/current-plan.md` after each phase completes — it survives context compression
+- One phase at a time — do not parallelize phase execution
+- After `implement:` phases, verify the build still passes: `make check`
+- `research:` and `write:` phases do not need `make check` — they produce documents, not code
 
 ## Worktree vs Direct Implementation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,9 +82,12 @@ For multi-spec tasks that span context windows, use `/run-plan`:
 
 ```bash
 /run-plan create "feature title" SPEC-001,SPEC-002,SPEC-003
-/run-plan next      # implement next spec (delegates to spec-implementer subagent)
+/run-plan create "feature title" SPEC-007 --full   # research → write → implement lifecycle
+/run-plan next      # execute next phase (delegates to appropriate subagent)
 /run-plan status    # check progress
 /run-plan resume    # continue after interruption
 ```
 
-State is persisted in `.claude/current-plan.md` and auto-injected via hooks on every prompt. Each spec runs in an isolated subagent with its own context window and worktree.
+Phase types: `research:` (spec-researcher), `write:` (spec-writer), `implement:` (spec-implementer).
+
+State is persisted in `.claude/current-plan.md` and auto-injected via hooks on every prompt. Each phase runs in an isolated subagent with its own context window.

--- a/crates/modules/src/sdd.rs
+++ b/crates/modules/src/sdd.rs
@@ -79,6 +79,8 @@ impl Module for SddModule {
             let playbook_files = [
                 "sdd/playbooks/create-new-spec.md",
                 "sdd/playbooks/coding-agent-workflow.md",
+                "sdd/playbooks/write-prd-td.md",
+                "sdd/playbooks/add-new-language.md",
             ];
 
             for src in &playbook_files {

--- a/crates/modules/src/sdd_checks.rs
+++ b/crates/modules/src/sdd_checks.rs
@@ -486,6 +486,127 @@ pub fn check_config_consistency(root: &Path) -> CheckResult {
     result
 }
 
+// Playbook files that should exist in both templates/sdd/playbooks/ and docs/playbooks/
+const SDD_PLAYBOOK_FILES: &[&str] = &[
+    "sdd/playbooks/create-new-spec.md",
+    "sdd/playbooks/coding-agent-workflow.md",
+    "sdd/playbooks/write-prd-td.md",
+    "sdd/playbooks/add-new-language.md",
+];
+
+/// Check 6: Playbook sync between templates/ (embedded) and docs/.
+pub fn check_playbook_sync(root: &Path) -> CheckResult {
+    let mut result = CheckResult::default();
+    let check = "playbook-sync";
+
+    let playbooks_dir = root.join("docs/playbooks");
+    if !playbooks_dir.is_dir() {
+        return result;
+    }
+
+    // Check that every embedded playbook has a corresponding file in docs/playbooks/
+    for embedded_path in SDD_PLAYBOOK_FILES {
+        let filename = Path::new(embedded_path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+
+        let project_path = playbooks_dir.join(filename);
+        let Some(embedded_content) = TemplateEngine::get_embedded_content(embedded_path) else {
+            continue;
+        };
+
+        if project_path.exists() {
+            CheckResult::ok(check, format!("playbooks/{filename} present"));
+        } else {
+            result.push(Diagnostic {
+                severity: Severity::Warning,
+                check: check.into(),
+                message: format!("playbooks/{filename} missing (exists in built-in templates)"),
+                fix: Some(AutoFix::UpdateTemplate {
+                    path: format!("docs/playbooks/{filename}"),
+                    content: embedded_content.to_vec(),
+                }),
+            });
+        }
+    }
+
+    // Check for docs/playbooks/ files that don't exist in embedded templates
+    if let Ok(rd) = std::fs::read_dir(&playbooks_dir) {
+        let embedded_filenames: Vec<&str> = SDD_PLAYBOOK_FILES
+            .iter()
+            .filter_map(|p| Path::new(p).file_name().and_then(|n| n.to_str()))
+            .collect();
+
+        for entry in rd.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            let is_md = Path::new(&name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
+            if is_md && !embedded_filenames.contains(&name.as_str()) {
+                result.push(Diagnostic {
+                    severity: Severity::Warning,
+                    check: check.into(),
+                    message: format!(
+                        "playbooks/{name} exists locally but not in built-in templates"
+                    ),
+                    fix: None,
+                });
+            }
+        }
+    }
+
+    result
+}
+
+/// Check 7: CLAUDE.md consistency with .claude/commands/.
+pub fn check_claude_md_consistency(root: &Path) -> CheckResult {
+    let mut result = CheckResult::default();
+    let check = "claude-md-consistency";
+
+    let claude_md_path = root.join("CLAUDE.md");
+    let Ok(claude_md) = std::fs::read_to_string(&claude_md_path) else {
+        // No CLAUDE.md — nothing to check
+        return result;
+    };
+
+    let commands_dir = root.join(".claude/commands");
+    if !commands_dir.is_dir() {
+        return result;
+    }
+
+    // Collect command names from .claude/commands/
+    let mut fs_commands: Vec<String> = Vec::new();
+    if let Ok(rd) = std::fs::read_dir(&commands_dir) {
+        for entry in rd.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if let Some(cmd) = name.strip_suffix(".md") {
+                fs_commands.push(cmd.to_string());
+            }
+        }
+    }
+    fs_commands.sort();
+
+    // Check each command file has a corresponding entry in CLAUDE.md slash commands table
+    for cmd in &fs_commands {
+        let pattern = format!("/{cmd}");
+        if claude_md.contains(&pattern) {
+            CheckResult::ok(check, format!("/{cmd} documented in CLAUDE.md"));
+        } else {
+            result.push(Diagnostic {
+                severity: Severity::Warning,
+                check: check.into(),
+                message: format!(
+                    "/{cmd} exists in .claude/commands/ but not found in CLAUDE.md slash commands table"
+                ),
+                fix: None,
+            });
+        }
+    }
+
+    result
+}
+
 /// Run all SDD health checks.
 pub fn run_all_checks(root: &Path) -> CheckResult {
     let mut result = CheckResult::default();
@@ -508,6 +629,14 @@ pub fn run_all_checks(root: &Path) -> CheckResult {
 
     println!("{}", console::style("[Config Consistency]").bold());
     result.merge(check_config_consistency(root));
+    println!();
+
+    println!("{}", console::style("[Playbook Sync]").bold());
+    result.merge(check_playbook_sync(root));
+    println!();
+
+    println!("{}", console::style("[CLAUDE.md Consistency]").bold());
+    result.merge(check_claude_md_consistency(root));
 
     result
 }
@@ -699,6 +828,73 @@ mod tests {
         setup_sdd_project(tmp.path());
         let r = check_config_consistency(tmp.path());
         assert_eq!(r.exit_code(), 0);
+    }
+
+    #[test]
+    fn playbook_sync_all_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sdd_project(tmp.path());
+        fs::create_dir_all(tmp.path().join("docs/playbooks")).unwrap();
+        for path in SDD_PLAYBOOK_FILES {
+            if let Some(content) = TemplateEngine::get_embedded_content(path) {
+                let filename = Path::new(path).file_name().unwrap();
+                fs::write(tmp.path().join("docs/playbooks").join(filename), content).unwrap();
+            }
+        }
+        let r = check_playbook_sync(tmp.path());
+        assert_eq!(r.exit_code(), 0);
+    }
+
+    #[test]
+    fn playbook_sync_missing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sdd_project(tmp.path());
+        fs::create_dir_all(tmp.path().join("docs/playbooks")).unwrap();
+        // Only write one playbook — others should be flagged
+        if let Some(content) =
+            TemplateEngine::get_embedded_content("sdd/playbooks/create-new-spec.md")
+        {
+            fs::write(
+                tmp.path().join("docs/playbooks/create-new-spec.md"),
+                content,
+            )
+            .unwrap();
+        }
+        let r = check_playbook_sync(tmp.path());
+        assert!(r.has_warnings());
+    }
+
+    #[test]
+    fn claude_md_consistency_all_documented() {
+        let tmp = tempfile::tempdir().unwrap();
+        let commands_dir = tmp.path().join(".claude/commands");
+        fs::create_dir_all(&commands_dir).unwrap();
+        fs::write(commands_dir.join("ship.md"), "ship command").unwrap();
+        fs::write(commands_dir.join("test.md"), "test command").unwrap();
+        fs::write(
+            tmp.path().join("CLAUDE.md"),
+            "# Project\n\n| `/ship` | Ship it |\n| `/test` | Test it |\n",
+        )
+        .unwrap();
+        let r = check_claude_md_consistency(tmp.path());
+        assert_eq!(r.exit_code(), 0);
+    }
+
+    #[test]
+    fn claude_md_consistency_missing_command() {
+        let tmp = tempfile::tempdir().unwrap();
+        let commands_dir = tmp.path().join(".claude/commands");
+        fs::create_dir_all(&commands_dir).unwrap();
+        fs::write(commands_dir.join("ship.md"), "ship command").unwrap();
+        fs::write(commands_dir.join("secret.md"), "secret command").unwrap();
+        fs::write(
+            tmp.path().join("CLAUDE.md"),
+            "# Project\n\n| `/ship` | Ship it |\n",
+        )
+        .unwrap();
+        let r = check_claude_md_consistency(tmp.path());
+        assert!(r.has_warnings());
+        assert!(r.diagnostics[0].message.contains("secret"));
     }
 
     #[test]

--- a/docs/playbooks/create-new-spec.md
+++ b/docs/playbooks/create-new-spec.md
@@ -5,9 +5,10 @@
 1. Find next SPEC-NNN in `docs/specs/_index.md`
 2. `mkdir -p docs/specs/active/SPEC-NNN`
 3. Copy templates: `cp docs/specs/_templates/{prd,technical-design}.md docs/specs/active/SPEC-NNN/`
-4. Fill in PRD (problem, goals, user stories)
-5. Fill in TD (API, implementation, tests)
-6. Register in `_index.md` Active table
+4. (Optional) If the spec requires competitor research or technical exploration, follow the `write-prd-td` playbook phases 1-2 before writing PRD/TD
+5. Fill in PRD (problem, goals, user stories)
+6. Fill in TD (API, implementation, tests)
+7. Register in `_index.md` Active table
 
 ## Lifecycle
 

--- a/docs/playbooks/write-prd-td.md
+++ b/docs/playbooks/write-prd-td.md
@@ -1,0 +1,104 @@
+# Playbook: Write PRD & TD (Anti-Forgetting)
+
+## Overview
+
+Complex PRD/TD writing involves large amounts of intermediate research (competitor analysis, tech stack evaluation, trade-off analysis). Long conversations cause context compression, losing earlier findings. This playbook solves this by splitting the work into 4 independent phases, each persisting results to disk.
+
+**Key principle**: Each phase can run in a **separate conversation**. Later phases read prior phase outputs from files, not from conversation history.
+
+## Prerequisites
+
+- Spec directory exists: `docs/specs/active/SPEC-NNN/`
+- Spec is registered in `docs/specs/_index.md`
+
+## Phases
+
+### Phase 1: Competitor Research
+
+**Input**: Spec directory path, problem domain description
+**Output**: `docs/specs/active/SPEC-NNN/research-competitors.md`
+
+1. Read the spec directory to understand the problem domain
+2. Identify 3-5 relevant competitors or prior art
+3. For each competitor, research:
+   - Core features and positioning
+   - Technical approach and stack
+   - Strengths and weaknesses
+   - Relevance to our project
+4. **Write findings to `research-competitors.md` incrementally** — do not wait until the end
+5. Summarize with a comparison table and preliminary recommendations
+6. Mark the research document status as "Complete"
+
+**Completion criteria**: `research-competitors.md` exists with filled competitor table, detailed analysis per competitor, and summary recommendations.
+
+### Phase 2: Technical Feasibility Analysis
+
+**Input**: Spec directory path (reads `research-competitors.md` from Phase 1)
+**Output**: `docs/specs/active/SPEC-NNN/research-tech.md`
+
+1. **Read `research-competitors.md`** to understand the landscape
+2. Read existing codebase structure (`Cargo.toml`, key modules) to understand current architecture
+3. Identify 2-4 candidate technical approaches
+4. For each approach, evaluate:
+   - Implementation complexity
+   - Compatibility with existing architecture
+   - Performance implications
+   - Maintenance burden
+5. **Write findings to `research-tech.md` incrementally**
+6. Produce a comparison table with recommendation
+7. Mark the research document status as "Complete"
+
+**Completion criteria**: `research-tech.md` exists with approach comparison table, detailed pros/cons per approach, and a clear recommended approach with justification.
+
+### Phase 3: PRD Writing
+
+**Input**: Spec directory path (reads both research docs from Phases 1-2)
+**Output**: `docs/specs/active/SPEC-NNN/prd.md`
+
+1. **Read `research-competitors.md` and `research-tech.md`**
+2. Read any existing PRD template or draft in the spec directory
+3. Write the PRD with:
+   - Problem statement (informed by competitor gaps)
+   - Goals and non-goals
+   - User stories
+   - Success metrics
+   - Scope boundaries (informed by technical feasibility)
+4. **Write to `prd.md` incrementally** — start with structure, then fill sections
+5. Cross-reference research docs for evidence-based decisions
+
+**Completion criteria**: `prd.md` exists with all sections filled, references to research findings, and clear scope.
+
+### Phase 4: TD Writing
+
+**Input**: Spec directory path (reads PRD + both research docs)
+**Output**: `docs/specs/active/SPEC-NNN/technical-design.md`
+
+1. **Read `prd.md`, `research-competitors.md`, and `research-tech.md`**
+2. Read relevant source code for the areas being modified
+3. Write the TD with:
+   - Architecture overview
+   - API design (informed by competitor patterns)
+   - Implementation plan (based on recommended technical approach)
+   - Task breakdown with dependencies
+   - Testing strategy
+   - Revision log
+4. **Write to `technical-design.md` incrementally**
+5. Ensure task breakdown aligns with PRD scope
+
+**Completion criteria**: `technical-design.md` exists with all sections filled, task breakdown with dependencies, and alignment with PRD goals.
+
+## Anti-Forgetting Rules
+
+1. **Incremental writes**: Every phase writes to its output file as it progresses, not just at the end. If the conversation is interrupted, partial progress is preserved.
+2. **File-based handoff**: Each phase reads only from files, never from prior conversation context. This means phases can safely run in separate conversations.
+3. **Structured output**: Research docs use tables and structured formats so downstream phases can quickly extract key conclusions.
+4. **Self-contained sections**: Each section in a research doc should be understandable without reading the full conversation that produced it.
+
+## Quick Reference
+
+```
+Phase 1: research-competitors.md  (can run independently)
+Phase 2: research-tech.md         (depends on Phase 1 output)
+Phase 3: prd.md                   (depends on Phases 1-2 output)
+Phase 4: technical-design.md      (depends on Phases 1-3 output)
+```

--- a/docs/specs/_templates/research.md
+++ b/docs/specs/_templates/research.md
@@ -4,6 +4,7 @@
 |-----------|----------------|
 | Spec ID   | SPEC-NNN       |
 | Title     | [Title]        |
+| Type      | competitors / tech-feasibility |
 | Status    | Draft          |
 | Created   | YYYY-MM-DD     |
 
@@ -16,15 +17,46 @@ _Context and motivation for this research._
 1. Question 1
 2. Question 2
 
+## Competitor Overview
+
+_Remove this section if research type is tech-feasibility._
+
+| Competitor | Positioning | Core Features | Tech Stack | Activity |
+|------------|-------------|---------------|------------|----------|
+|            |             |               |            |          |
+
+## Competitor Detail
+
+### [Competitor Name]
+
+**Strengths**
+- ...
+
+**Weaknesses**
+- ...
+
+**Relevance to This Project**
+- ...
+
+## Technical Approach Comparison
+
+_Remove this section if research type is competitors._
+
+| Approach | Pros | Cons | Complexity | Recommendation |
+|----------|------|------|------------|----------------|
+|          |      |      |            |                |
+
 ## Findings
 
 ### [Finding 1]
 
 _Description, evidence, implications._
 
-## Recommendations
+## Conclusions & Recommendations
 
-- Recommendation 1
+- **Recommended approach**: ...
+- **Key decision points**: ...
+- **Risks**: ...
 
 ## Open Questions
 

--- a/templates/sdd/playbooks/add-new-language.md
+++ b/templates/sdd/playbooks/add-new-language.md
@@ -1,0 +1,94 @@
+# Playbook: Add a New Language
+
+How to add full support for a new programming language to harn.
+
+## Touchpoints (6 areas)
+
+### 1. Build Templates
+
+Create 3 template files with standard targets (`dev`, `build`, `test`, `lint`, `fmt`, `clean`, `help`):
+
+```
+templates/build/make/<lang>
+templates/build/just/<lang>
+templates/build/task/<lang>
+```
+
+Reference existing templates (e.g., `templates/build/make/go`) for style.
+
+### 2. Git Ignore — `crates/modules/src/git.rs`
+
+Add a match arm in the `for lang in &ctx.config.stacks.languages` block:
+
+```rust
+"<lang>" => {
+    content.push_str("# <Lang>\n<patterns>\n\n");
+}
+```
+
+### 3. Quality Config — `crates/modules/src/quality.rs` + template
+
+Create the linter config template:
+
+```
+templates/quality/<config-file>
+```
+
+Add a match arm in quality.rs to render it:
+
+```rust
+"<lang>" => {
+    let src = "quality/<config-file>";
+    if engine.has_template(src) {
+        let dst = ctx.path("<output-file>");
+        if engine.render_to(src, &vars, &dst, force)? {
+            created.push("<output-file>".into());
+        }
+    }
+}
+```
+
+### 4. Agent Permissions — `crates/modules/src/agent.rs`
+
+Add a match arm in `build_claude_settings()` to grant tool permissions:
+
+```rust
+"<lang>" => {
+    perms.push("Bash(<compiler>:*)".into());
+    perms.push("Bash(<package-mgr>:*)".into());
+}
+```
+
+### 5. Docker Template
+
+Create a Dockerfile template:
+
+```
+templates/docker/Dockerfile.<lang>
+```
+
+No code changes needed — `docker.rs` auto-discovers `Dockerfile.<lang>`.
+
+### 6. Documentation
+
+Update these files:
+- `README.md` — Language Support table
+- `CLAUDE.md` — already references this playbook in Extension Points
+
+## Verification
+
+```bash
+make check    # Must pass (fmt + clippy + tests)
+```
+
+## Existing Languages
+
+| Language | Build Tool | Linter | Key Patterns |
+|----------|-----------|--------|--------------|
+| rust | cargo | rust-toolchain.toml | target/ |
+| go | go | .golangci.yml | bin/, coverage.out |
+| typescript | npm | eslint + prettier | node_modules/, dist/ |
+| dart | flutter | — | .dart_tool/, build/ |
+| python | uv | ruff.toml | \_\_pycache\_\_/, .venv/ |
+| java | gradle | checkstyle.xml | build/, .gradle/, *.class |
+| cpp / c | cmake | .clang-format | build/, *.o, *.a |

--- a/templates/sdd/playbooks/create-new-spec.md
+++ b/templates/sdd/playbooks/create-new-spec.md
@@ -5,9 +5,10 @@
 1. Find next SPEC-NNN in `docs/specs/_index.md`
 2. `mkdir -p docs/specs/active/SPEC-NNN`
 3. Copy templates: `cp docs/specs/_templates/{prd,technical-design}.md docs/specs/active/SPEC-NNN/`
-4. Fill in PRD (problem, goals, user stories)
-5. Fill in TD (API, implementation, tests)
-6. Register in `_index.md` Active table
+4. (Optional) If the spec requires competitor research or technical exploration, follow the `write-prd-td` playbook phases 1-2 before writing PRD/TD
+5. Fill in PRD (problem, goals, user stories)
+6. Fill in TD (API, implementation, tests)
+7. Register in `_index.md` Active table
 
 ## Lifecycle
 

--- a/templates/sdd/playbooks/write-prd-td.md
+++ b/templates/sdd/playbooks/write-prd-td.md
@@ -1,0 +1,104 @@
+# Playbook: Write PRD & TD (Anti-Forgetting)
+
+## Overview
+
+Complex PRD/TD writing involves large amounts of intermediate research (competitor analysis, tech stack evaluation, trade-off analysis). Long conversations cause context compression, losing earlier findings. This playbook solves this by splitting the work into 4 independent phases, each persisting results to disk.
+
+**Key principle**: Each phase can run in a **separate conversation**. Later phases read prior phase outputs from files, not from conversation history.
+
+## Prerequisites
+
+- Spec directory exists: `docs/specs/active/SPEC-NNN/`
+- Spec is registered in `docs/specs/_index.md`
+
+## Phases
+
+### Phase 1: Competitor Research
+
+**Input**: Spec directory path, problem domain description
+**Output**: `docs/specs/active/SPEC-NNN/research-competitors.md`
+
+1. Read the spec directory to understand the problem domain
+2. Identify 3-5 relevant competitors or prior art
+3. For each competitor, research:
+   - Core features and positioning
+   - Technical approach and stack
+   - Strengths and weaknesses
+   - Relevance to our project
+4. **Write findings to `research-competitors.md` incrementally** — do not wait until the end
+5. Summarize with a comparison table and preliminary recommendations
+6. Mark the research document status as "Complete"
+
+**Completion criteria**: `research-competitors.md` exists with filled competitor table, detailed analysis per competitor, and summary recommendations.
+
+### Phase 2: Technical Feasibility Analysis
+
+**Input**: Spec directory path (reads `research-competitors.md` from Phase 1)
+**Output**: `docs/specs/active/SPEC-NNN/research-tech.md`
+
+1. **Read `research-competitors.md`** to understand the landscape
+2. Read existing codebase structure (`Cargo.toml`, key modules) to understand current architecture
+3. Identify 2-4 candidate technical approaches
+4. For each approach, evaluate:
+   - Implementation complexity
+   - Compatibility with existing architecture
+   - Performance implications
+   - Maintenance burden
+5. **Write findings to `research-tech.md` incrementally**
+6. Produce a comparison table with recommendation
+7. Mark the research document status as "Complete"
+
+**Completion criteria**: `research-tech.md` exists with approach comparison table, detailed pros/cons per approach, and a clear recommended approach with justification.
+
+### Phase 3: PRD Writing
+
+**Input**: Spec directory path (reads both research docs from Phases 1-2)
+**Output**: `docs/specs/active/SPEC-NNN/prd.md`
+
+1. **Read `research-competitors.md` and `research-tech.md`**
+2. Read any existing PRD template or draft in the spec directory
+3. Write the PRD with:
+   - Problem statement (informed by competitor gaps)
+   - Goals and non-goals
+   - User stories
+   - Success metrics
+   - Scope boundaries (informed by technical feasibility)
+4. **Write to `prd.md` incrementally** — start with structure, then fill sections
+5. Cross-reference research docs for evidence-based decisions
+
+**Completion criteria**: `prd.md` exists with all sections filled, references to research findings, and clear scope.
+
+### Phase 4: TD Writing
+
+**Input**: Spec directory path (reads PRD + both research docs)
+**Output**: `docs/specs/active/SPEC-NNN/technical-design.md`
+
+1. **Read `prd.md`, `research-competitors.md`, and `research-tech.md`**
+2. Read relevant source code for the areas being modified
+3. Write the TD with:
+   - Architecture overview
+   - API design (informed by competitor patterns)
+   - Implementation plan (based on recommended technical approach)
+   - Task breakdown with dependencies
+   - Testing strategy
+   - Revision log
+4. **Write to `technical-design.md` incrementally**
+5. Ensure task breakdown aligns with PRD scope
+
+**Completion criteria**: `technical-design.md` exists with all sections filled, task breakdown with dependencies, and alignment with PRD goals.
+
+## Anti-Forgetting Rules
+
+1. **Incremental writes**: Every phase writes to its output file as it progresses, not just at the end. If the conversation is interrupted, partial progress is preserved.
+2. **File-based handoff**: Each phase reads only from files, never from prior conversation context. This means phases can safely run in separate conversations.
+3. **Structured output**: Research docs use tables and structured formats so downstream phases can quickly extract key conclusions.
+4. **Self-contained sections**: Each section in a research doc should be understandable without reading the full conversation that produced it.
+
+## Quick Reference
+
+```
+Phase 1: research-competitors.md  (can run independently)
+Phase 2: research-tech.md         (depends on Phase 1 output)
+Phase 3: prd.md                   (depends on Phases 1-2 output)
+Phase 4: technical-design.md      (depends on Phases 1-3 output)
+```

--- a/templates/sdd/specs/_templates/research.md
+++ b/templates/sdd/specs/_templates/research.md
@@ -4,6 +4,7 @@
 |-----------|----------------|
 | Spec ID   | SPEC-NNN       |
 | Title     | [Title]        |
+| Type      | competitors / tech-feasibility |
 | Status    | Draft          |
 | Created   | YYYY-MM-DD     |
 
@@ -16,15 +17,46 @@ _Context and motivation for this research._
 1. Question 1
 2. Question 2
 
+## Competitor Overview
+
+_Remove this section if research type is tech-feasibility._
+
+| Competitor | Positioning | Core Features | Tech Stack | Activity |
+|------------|-------------|---------------|------------|----------|
+|            |             |               |            |          |
+
+## Competitor Detail
+
+### [Competitor Name]
+
+**Strengths**
+- ...
+
+**Weaknesses**
+- ...
+
+**Relevance to This Project**
+- ...
+
+## Technical Approach Comparison
+
+_Remove this section if research type is competitors._
+
+| Approach | Pros | Cons | Complexity | Recommendation |
+|----------|------|------|------------|----------------|
+|          |      |      |            |                |
+
 ## Findings
 
 ### [Finding 1]
 
 _Description, evidence, implications._
 
-## Recommendations
+## Conclusions & Recommendations
 
-- Recommendation 1
+- **Recommended approach**: ...
+- **Key decision points**: ...
+- **Risks**: ...
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

- **write-prd-td playbook**: 4-phase anti-forgetting workflow (competitor research → tech feasibility → PRD → TD) with incremental file persistence, designed so each phase can run in a separate conversation
- **spec-researcher & spec-writer subagents**: New Claude agents for automated research and document writing, integrated into `/run-plan` with `research:` and `write:` phase types
- **`/run-plan --full` flag**: Creates full lifecycle plans (research → write → implement) for a single spec
- **`harn doctor` checks**: Playbook sync between templates/ and docs/, CLAUDE.md slash commands consistency with .claude/commands/
- **Expanded research template**: Competitor overview table, detailed analysis sections, technical approach comparison
- **Synced templates**: add-new-language playbook, create-new-spec research step reference

## Test plan

- [x] `make check` passes (fmt + clippy + 15 tests including 4 new)
- [ ] `harn doctor` reports `[Playbook Sync]` and `[CLAUDE.md Consistency]` sections
- [ ] `/run-plan create "test" SPEC-NNN --full` generates 5-phase plan
- [ ] `harn init` generates all 4 playbooks in docs/playbooks/

🤖 Generated with [Claude Code](https://claude.com/claude-code)