### PR TITLE
refactor: extract shared SDD_PLAYBOOK_FILES const and add coverage test

### DIFF
--- a/crates/modules/src/sdd.rs
+++ b/crates/modules/src/sdd.rs
@@ -3,6 +3,15 @@ use harn_core::context::ProjectContext;
 use harn_core::module::{Module, ModuleId};
 use harn_templates::TemplateEngine;
 
+/// Playbook template paths shipped with the SDD module.
+/// Used by both generation (`SddModule`) and doctor checks (`sdd_checks`).
+pub const SDD_PLAYBOOK_FILES: &[&str] = &[
+    "sdd/playbooks/create-new-spec.md",
+    "sdd/playbooks/coding-agent-workflow.md",
+    "sdd/playbooks/write-prd-td.md",
+    "sdd/playbooks/add-new-language.md",
+];
+
 /// Spec-Driven Development documentation structure.
 ///
 /// Generates:
@@ -76,14 +85,7 @@ impl Module for SddModule {
         let include_playbooks = sdd_config.is_none_or(|c| c.playbooks);
 
         if include_playbooks {
-            let playbook_files = [
-                "sdd/playbooks/create-new-spec.md",
-                "sdd/playbooks/coding-agent-workflow.md",
-                "sdd/playbooks/write-prd-td.md",
-                "sdd/playbooks/add-new-language.md",
-            ];
-
-            for src in &playbook_files {
+            for src in SDD_PLAYBOOK_FILES {
                 let rel = src.strip_prefix("sdd/").unwrap();
                 let dst = ctx.path(&format!("docs/{rel}"));
                 if engine.copy_to(src, &dst, force)? {

--- a/crates/modules/src/sdd_checks.rs
+++ b/crates/modules/src/sdd_checks.rs
@@ -1,3 +1,4 @@
+use crate::sdd::SDD_PLAYBOOK_FILES;
 use harn_core::doctor::{AutoFix, CheckResult, Diagnostic, Severity};
 use harn_templates::TemplateEngine;
 use std::collections::HashMap;
@@ -485,14 +486,6 @@ pub fn check_config_consistency(root: &Path) -> CheckResult {
 
     result
 }
-
-// Playbook files that should exist in both templates/sdd/playbooks/ and docs/playbooks/
-const SDD_PLAYBOOK_FILES: &[&str] = &[
-    "sdd/playbooks/create-new-spec.md",
-    "sdd/playbooks/coding-agent-workflow.md",
-    "sdd/playbooks/write-prd-td.md",
-    "sdd/playbooks/add-new-language.md",
-];
 
 /// Check 6: Playbook sync between templates/ (embedded) and docs/.
 pub fn check_playbook_sync(root: &Path) -> CheckResult {

--- a/crates/modules/tests/template_coverage.rs
+++ b/crates/modules/tests/template_coverage.rs
@@ -1,3 +1,4 @@
+use harn_modules::sdd::SDD_PLAYBOOK_FILES;
 use harn_templates::TemplateEngine;
 
 /// Verify that all build tool + language combinations have templates.
@@ -66,6 +67,29 @@ fn command_templates_exist_for_all_defaults() {
         assert!(
             engine.has_template(&path),
             "Missing command template: {path}"
+        );
+    }
+}
+
+/// Verify that every playbook in templates/sdd/playbooks/ is listed in `SDD_PLAYBOOK_FILES`.
+#[test]
+fn playbook_templates_covered_by_sdd_module() {
+    let engine = TemplateEngine::new();
+    let embedded = engine.list_templates("sdd/playbooks/");
+
+    // Every embedded playbook must be in the const
+    for path in &embedded {
+        assert!(
+            SDD_PLAYBOOK_FILES.contains(&path.as_str()),
+            "Playbook template '{path}' exists in templates/ but is not listed in SDD_PLAYBOOK_FILES — add it to sdd.rs"
+        );
+    }
+
+    // Every entry in the const must exist as an embedded template
+    for path in SDD_PLAYBOOK_FILES {
+        assert!(
+            engine.has_template(path),
+            "SDD_PLAYBOOK_FILES lists '{path}' but the template file does not exist"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Extract `SDD_PLAYBOOK_FILES` const from duplicated definitions in `sdd.rs` (local var) and `sdd_checks.rs` (module const) into a single `pub const` in `sdd.rs`
- `sdd_checks.rs` now imports from `crate::sdd` — single source of truth
- New integration test `playbook_templates_covered_by_sdd_module` in `template_coverage.rs` catches future drift bidirectionally

## Test plan

- [x] `make check` passes (21 tests including new `playbook_templates_covered_by_sdd_module`)
- [x] Adding a playbook to `templates/sdd/playbooks/` without updating `SDD_PLAYBOOK_FILES` would fail the test

🤖 Generated with [Claude Code](https://claude.com/claude-code)