### PR TITLE
refactor: extract url_encode to harn_core and document issue command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ make clean        # cargo clean
 make install      # install to cargo bin
 make run          # run with args (make run ARGS="init .")
 make help         # show all targets (default)
+
+harn issue        # submit an issue to the harn repo (interactive)
 ```
 
 ## Slash Commands

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,9 +3,8 @@ mod interactive;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use console::style;
-use harn_core::{HarnConfig, ProjectContext};
+use harn_core::{HarnConfig, ProjectContext, url_encode};
 use harn_modules::ModuleRegistry;
-use std::fmt::Write as _;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -509,22 +508,6 @@ fn open_issue_in_browser(title: &str, body: &str, label: &str) -> Result<()> {
     } else {
         anyhow::bail!("failed to open browser")
     }
-}
-
-fn url_encode(s: &str) -> String {
-    let mut result = String::with_capacity(s.len() * 3);
-    for byte in s.bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                result.push(byte as char);
-            }
-            _ => {
-                result.push('%');
-                let _ = write!(result, "{byte:02X}");
-            }
-        }
-    }
-    result
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,7 +3,9 @@ pub mod context;
 pub mod date;
 pub mod doctor;
 pub mod module;
+pub mod url;
 
 pub use config::HarnConfig;
 pub use context::ProjectContext;
 pub use module::{Module, ModuleId};
+pub use url::url_encode;

--- a/crates/core/src/url.rs
+++ b/crates/core/src/url.rs
@@ -1,0 +1,39 @@
+use std::fmt::Write as _;
+
+/// Percent-encode a string for use in URL query parameters (RFC 3986 unreserved chars).
+pub fn url_encode(s: &str) -> String {
+    let mut result = String::with_capacity(s.len() * 3);
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                result.push(byte as char);
+            }
+            _ => {
+                result.push('%');
+                let _ = write!(result, "{byte:02X}");
+            }
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unreserved_chars_unchanged() {
+        assert_eq!(url_encode("hello-world_2.0~test"), "hello-world_2.0~test");
+    }
+
+    #[test]
+    fn spaces_and_special_chars_encoded() {
+        assert_eq!(url_encode("a b"), "a%20b");
+        assert_eq!(url_encode("foo&bar=baz"), "foo%26bar%3Dbaz");
+    }
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(url_encode(""), "");
+    }
+}


### PR DESCRIPTION
## Summary

- Extract `url_encode` from `crates/cli/src/main.rs` to `harn_core::url` with 3 unit tests
- Add `harn issue` to CLAUDE.md Commands table
- Retro follow-up from PR #8

## Test plan

- [x] `make check` passes (28 tests, clippy clean)
- [x] `url_encode` unit tests: unreserved chars, special chars, empty string

🤖 Generated with [Claude Code](https://claude.com/claude-code)