### PR TITLE
feat: add Qoder IDE support and fix doc drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,8 @@ project/
 ├── AGENTS.md                     # Universal agent context
 ├── Makefile                      # Unified build (language-aware)
 ├── harn.toml                     # Reproducible config
-├── .claude/
-│   ├── settings.json             # Permissions + pre-commit hook
-│   └── commands/                 # Slash commands
-├── .cursor/rules                 # Cursor AI rules
-├── .windsurfrules                # Windsurf AI rules
+├── .claude/                      # Claude Code config + slash commands
+├── .<tool>/                      # Per-tool AI rules (cursor, windsurf, cline, qoder, ...)
 ├── .github/workflows/            # CI/CD pipelines
 ├── .vscode/                      # Editor settings
 ├── .editorconfig                 # Cross-editor formatting
@@ -84,7 +81,7 @@ project/
 |--------|-------------|-------------|
 | `sdd` | Spec-Driven Development docs | playbooks, reference |
 | `ci` | CI/CD pipelines | github, gitlab, gitea |
-| `agent` | AI coding agent configs | claude, cursor, windsurf, cline, opencode |
+| `agent` | AI coding agent configs | claude, cursor, windsurf, cline, opencode, qoder |
 | `build` | Build orchestration | make, just, task |
 | `ide` | Editor configuration | vscode, zed (jetbrains, vim planned) |
 | `git` | Git config | .gitignore (language-aware) |
@@ -165,8 +162,10 @@ harn init [dir]              Initialize a new project (interactive)
 harn init [dir] -c harn.toml Config-driven init (non-interactive)
 harn add <module> [dir]      Add a module to existing project
 harn spec [title] -d [dir]   Create a new Spec
+harn doctor [dir]            Diagnose SDD project health
 harn modules                 List available modules
 harn example                 Generate example harn.toml
+harn issue                   Submit an issue to harn project
 ```
 
 ## Contributing

--- a/crates/cli/src/interactive.rs
+++ b/crates/cli/src/interactive.rs
@@ -171,8 +171,8 @@ fn gather_ci_config() -> Result<CiConfig> {
 }
 
 fn gather_agent_config() -> Result<AgentConfig> {
-    let tool_options = &["claude", "cursor", "windsurf", "cline", "opencode"];
-    let tool_defaults = vec![true, false, false, false, false];
+    let tool_options = &["claude", "cursor", "windsurf", "cline", "opencode", "qoder"];
+    let tool_defaults = vec![true, false, false, false, false, false];
     let selected = MultiSelect::new()
         .with_prompt("AI coding tools")
         .items(tool_options)

--- a/crates/modules/src/agent.rs
+++ b/crates/modules/src/agent.rs
@@ -11,6 +11,7 @@ use harn_templates::TemplateEngine;
 /// - Windsurf: .windsurfrules
 /// - Cline: .clinerules
 /// - `OpenCode`: .opencode/commands/
+/// - Qoder: .qoder/rules/
 ///
 /// Also generates CLAUDE.md and AGENTS.md project context files.
 pub struct AgentModule;
@@ -25,7 +26,7 @@ impl Module for AgentModule {
     }
 
     fn description(&self) -> &str {
-        "AI coding agent configs (Claude, Cursor, Windsurf, Cline, OpenCode)"
+        "AI coding agent configs (Claude, Cursor, Windsurf, Cline, OpenCode, Qoder)"
     }
 
     fn generate(&self, ctx: &mut ProjectContext) -> Result<Vec<String>> {
@@ -66,6 +67,9 @@ impl Module for AgentModule {
                 }
                 "opencode" => {
                     created.extend(self.generate_opencode(ctx, &engine, &vars, &agent_config)?);
+                }
+                "qoder" => {
+                    created.extend(self.generate_qoder(ctx, &engine, &vars)?);
                 }
                 _ => {} // Unknown tool, skip
             }
@@ -176,6 +180,20 @@ impl AgentModule {
         Ok(created)
     }
 
+    fn generate_qoder(
+        &self,
+        ctx: &ProjectContext,
+        engine: &TemplateEngine,
+        vars: &std::collections::HashMap<String, String>,
+    ) -> Result<Vec<String>> {
+        let mut created = Vec::new();
+        let dst = ctx.path(".qoder/rules/harn.md");
+        if engine.render_to("agent/qoderrules", vars, &dst, ctx.force)? {
+            created.push(".qoder/rules/harn.md".into());
+        }
+        Ok(created)
+    }
+
     fn build_slash_commands_table(commands: &[String]) -> String {
         let descriptions: &[(&str, &str, &str)] = &[
             ("ship", "/ship [msg]", "Lint + test + commit + push + PR"),
@@ -193,6 +211,11 @@ impl AgentModule {
             ("pr", "/pr [title]", "Create pull request"),
             ("deploy", "/deploy", "Deploy"),
             ("sync-commands", "/sync-commands", "Sync slash commands"),
+            (
+                "run-plan",
+                "/run-plan",
+                "Orchestrate multi-spec long-running plans",
+            ),
         ];
 
         let mut rows = Vec::new();

--- a/crates/modules/tests/template_coverage.rs
+++ b/crates/modules/tests/template_coverage.rs
@@ -60,6 +60,7 @@ fn command_templates_exist_for_all_defaults() {
         "ci",
         "pr",
         "deploy",
+        "run-plan",
     ];
 
     for cmd in &default_commands {
@@ -67,6 +68,30 @@ fn command_templates_exist_for_all_defaults() {
         assert!(
             engine.has_template(&path),
             "Missing command template: {path}"
+        );
+    }
+}
+
+/// Verify that every command template has a description entry in agent.rs.
+/// Reads the source file and checks that each template name appears in
+/// `build_slash_commands_table`.
+#[test]
+fn slash_command_descriptions_cover_all_templates() {
+    let engine = TemplateEngine::new();
+    let templates = engine.list_templates("agent/commands/");
+
+    let agent_src =
+        std::fs::read_to_string("src/agent.rs").expect("Could not read agent.rs source");
+
+    for tpl in &templates {
+        // template path is "agent/commands/foo.md", extract "foo"
+        let name = tpl
+            .strip_prefix("agent/commands/")
+            .and_then(|s| s.strip_suffix(".md"))
+            .unwrap_or(tpl);
+        assert!(
+            agent_src.contains(&format!("\"{name}\"")),
+            "Command template '{name}' exists but has no entry in build_slash_commands_table() — add it to agent.rs"
         );
     }
 }

--- a/templates/agent/qoderrules
+++ b/templates/agent/qoderrules
@@ -1,0 +1,12 @@
+# {{ project_name }}
+
+## Rules
+
+- Always run `make lint` before committing
+- Always run `make test` before committing
+- Use conventional commit messages: feat:, fix:, docs:, refactor:, test:, chore:
+- Check `docs/reference/types/` for existing type definitions before creating new ones
+- Update reference docs when changing APIs, types, or database schema
+- Follow SDD methodology: specs in `docs/specs/`, reference in `docs/reference/`
+- No hardcoded secrets — use environment variables
+- All API responses use standard envelope format


### PR DESCRIPTION
## Summary

- Add Qoder (Alibaba's AI IDE) as a supported tool — generates `.qoder/rules/harn.md`
- Fix 3 doc drift issues found by `/doc-audit`: `run-plan` missing from slash command descriptions, `harn doctor` and `harn issue` missing from README, qoder missing from README modules table
- Add coverage test ensuring every command template has a matching description entry in `build_slash_commands_table()`
- Simplify README "What It Generates" tree to use generic `.<tool>/` instead of listing each tool individually

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (29 tests, including new `slash_command_descriptions_cover_all_templates`)
- [x] `harn doctor` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)