### PR TITLE
fix: add Codex agent support and complete doctor validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Universal project harness with Spec-Driven Development (SDD) methodology.
 
 **harn** equips your project with production-grade development infrastructure in one command: SDD documentation, AI agent configs, CI/CD pipelines, build orchestration, and quality gates.
 
+`AGENTS.md` is generated as the primary repo brief for Codex and other tool-agnostic coding agents, with tool-specific overlays such as `.claude/` added when selected.
+
 Distilled from patterns across multiple production Rust/Go/TypeScript/Flutter/Python/Java/C++ projects.
 
 ## Install
@@ -53,8 +55,8 @@ harn add ci
 
 ```
 project/
-├── CLAUDE.md                     # AI agent context
-├── AGENTS.md                     # Universal agent context
+├── AGENTS.md                     # Primary repo context for Codex and generic agents
+├── CLAUDE.md                     # Claude Code supplement + slash commands
 ├── Makefile                      # Unified build (language-aware)
 ├── harn.toml                     # Reproducible config
 ├── .claude/                      # Claude Code config + slash commands
@@ -85,7 +87,7 @@ project/
 |--------|-------------|-------------|
 | `sdd` | Spec-Driven Development docs | playbooks, reference |
 | `ci` | CI/CD pipelines | github, gitlab, gitea/codeberg |
-| `agent` | AI coding agent configs | claude, cursor, windsurf, cline, opencode, qoder |
+| `agent` | AI coding agent configs | claude, codex, cursor, windsurf, cline, opencode, qoder |
 | `build` | Build orchestration | make, just, task |
 | `ide` | Editor configuration | vscode, zed (jetbrains, vim planned) |
 | `git` | Git config | .gitignore (language-aware), .gitattributes |
@@ -115,7 +117,7 @@ provider = "github"       # github | gitlab | gitea
 workflows = ["ci", "cd"]
 
 [modules.agent]
-tools = ["claude", "cursor"]
+tools = ["claude", "codex", "cursor"]
 commands = ["ship", "implement", "spec", "lint", "test", "review"]
 pre_commit_hook = true
 
@@ -158,7 +160,7 @@ harn implements **Harness Engineering** — treating developer infrastructure as
 
 1. **Convention over Configuration** — sensible defaults, escape hatches via `harn.toml`
 2. **Spec-Driven Development** — define features as Specs (PRD + TD), track lifecycle
-3. **AI-Agent-First** — CLAUDE.md + slash commands for AI-assisted workflows
+3. **AI-Agent-First** — AGENTS.md as primary context plus tool-specific overlays
 4. **Quality Gates** — optional pre-commit hooks enforce `make lint && make test` (`pre_commit_hook = true`)
 5. **SSOT Documentation** — reference docs as single source of truth
 6. **Reproducible** — `harn.toml` captures all decisions for team sharing

--- a/crates/cli/src/interactive.rs
+++ b/crates/cli/src/interactive.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use console::style;
 use dialoguer::{Confirm, FuzzySelect, Input, MultiSelect};
+use harn_core::agent_tools::SUPPORTED_AGENT_TOOLS;
 use harn_core::config::*;
 use std::path::Path;
 
@@ -51,7 +52,7 @@ pub fn gather_config(root: &Path) -> Result<HarnConfig> {
     let module_options = &[
         ("sdd", "SDD documentation (specs, reference, playbooks)"),
         ("ci", "CI/CD pipelines"),
-        ("agent", "AI agent configs (Claude, Cursor, etc.)"),
+        ("agent", "AI agent configs (Claude, Codex, Cursor, etc.)"),
         ("build", "Build orchestration (Make, Just, Task)"),
         ("ide", "IDE/editor configs"),
         ("git", "Git config (.gitignore, hooks)"),
@@ -171,11 +172,11 @@ fn gather_ci_config() -> Result<CiConfig> {
 }
 
 fn gather_agent_config() -> Result<AgentConfig> {
-    let tool_options = &["claude", "cursor", "windsurf", "cline", "opencode", "qoder"];
-    let tool_defaults = vec![true, false, false, false, false, false];
+    let tool_options: Vec<&str> = SUPPORTED_AGENT_TOOLS.iter().map(|tool| tool.id).collect();
+    let tool_defaults: Vec<bool> = tool_options.iter().map(|tool| *tool == "claude").collect();
     let selected = MultiSelect::new()
         .with_prompt("AI coding tools")
-        .items(tool_options)
+        .items(&tool_options)
         .defaults(&tool_defaults)
         .interact()?;
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use console::style;
 use harn_core::context::WriteStatus;
-use harn_core::{HarnConfig, ProjectContext, url_encode};
+use harn_core::{AGENT_TOOL_LIST, HarnConfig, ProjectContext, url_encode};
 use harn_modules::ModuleRegistry;
 use std::io::IsTerminal;
 use std::path::PathBuf;
@@ -224,21 +224,39 @@ fn cmd_init(
     println!();
     println!("{}", style("Setup complete!").green().bold());
     println!();
+    let agent_tools = ctx
+        .config
+        .modules
+        .agent
+        .as_ref()
+        .map_or(&[][..], |agent| &agent.tools);
     println!("Next steps:");
-    println!("  1. Review and customize {}", style("CLAUDE.md").cyan());
-    println!(
-        "  2. Edit {} permissions",
-        style(".claude/settings.json").cyan()
-    );
+    println!("  1. Review and customize {}", style("AGENTS.md").cyan());
+    if agent_tools.iter().any(|tool| tool == "claude") {
+        println!(
+            "  2. Review {} and slash commands",
+            style(".claude/settings.json").cyan()
+        );
+    } else if agent_tools.iter().any(|tool| tool == "opencode") {
+        println!(
+            "  2. Review generated {}",
+            style(".opencode/commands/").cyan()
+        );
+    } else {
+        println!(
+            "  2. Confirm your configured agent tools in {}",
+            style("harn.toml").cyan()
+        );
+    }
     println!(
         "  3. Create your first spec: {}",
-        style("/spec create \"Feature\"").yellow()
+        style("harn spec \"Feature\"").yellow()
     );
     println!(
         "  4. Start developing: {}",
-        style("/implement SPEC-001").yellow()
+        style("share AGENTS.md with your coding agent").yellow()
     );
-    println!("  5. Ship changes: {}", style("/ship").yellow());
+    println!("  5. Verify changes with {}", style("make check").yellow());
 
     Ok(())
 }
@@ -394,7 +412,7 @@ fn cmd_doctor(directory: PathBuf, fix: bool) -> Result<()> {
     let has_sdd = root.join("docs/specs").exists();
     let config_path = root.join("harn.toml");
     let config = if config_path.exists() {
-        HarnConfig::load(&config_path).ok()
+        Some(HarnConfig::load(&config_path)?)
     } else {
         None
     };
@@ -478,6 +496,7 @@ fn cmd_example(output: PathBuf) -> Result<()> {
         style("OK").green().bold(),
         output.display()
     );
+    println!("Agent tool values: {}", style(AGENT_TOOL_LIST).cyan());
     Ok(())
 }
 

--- a/crates/core/src/agent_tools.rs
+++ b/crates/core/src/agent_tools.rs
@@ -1,0 +1,143 @@
+use anyhow::ensure;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentToolArtifact {
+    File(&'static str),
+    CommandsDir(&'static str),
+}
+
+impl AgentToolArtifact {
+    pub fn expected_paths(self, commands: &[String]) -> Vec<String> {
+        match self {
+            Self::File(path) => vec![path.to_string()],
+            Self::CommandsDir(dir) => commands
+                .iter()
+                .map(|command| format!("{dir}/{command}.md"))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AgentTool {
+    pub id: &'static str,
+    pub display_name: &'static str,
+    pub artifacts: &'static [AgentToolArtifact],
+    pub doctor_note: Option<&'static str>,
+}
+
+const CLAUDE_ARTIFACTS: &[AgentToolArtifact] = &[
+    AgentToolArtifact::File(".claude/settings.json"),
+    AgentToolArtifact::CommandsDir(".claude/commands"),
+];
+const CURSOR_ARTIFACTS: &[AgentToolArtifact] = &[AgentToolArtifact::File(".cursor/rules")];
+const WINDSURF_ARTIFACTS: &[AgentToolArtifact] = &[AgentToolArtifact::File(".windsurfrules")];
+const CLINE_ARTIFACTS: &[AgentToolArtifact] = &[AgentToolArtifact::File(".clinerules")];
+const OPENCODE_ARTIFACTS: &[AgentToolArtifact] =
+    &[AgentToolArtifact::CommandsDir(".opencode/commands")];
+const QODER_ARTIFACTS: &[AgentToolArtifact] = &[AgentToolArtifact::File(".qoder/rules/harn.md")];
+const CODEX_ARTIFACTS: &[AgentToolArtifact] = &[];
+
+pub const SUPPORTED_AGENT_TOOLS: &[AgentTool] = &[
+    AgentTool {
+        id: "claude",
+        display_name: "Claude",
+        artifacts: CLAUDE_ARTIFACTS,
+        doctor_note: None,
+    },
+    AgentTool {
+        id: "cursor",
+        display_name: "Cursor",
+        artifacts: CURSOR_ARTIFACTS,
+        doctor_note: None,
+    },
+    AgentTool {
+        id: "windsurf",
+        display_name: "Windsurf",
+        artifacts: WINDSURF_ARTIFACTS,
+        doctor_note: None,
+    },
+    AgentTool {
+        id: "cline",
+        display_name: "Cline",
+        artifacts: CLINE_ARTIFACTS,
+        doctor_note: None,
+    },
+    AgentTool {
+        id: "opencode",
+        display_name: "OpenCode",
+        artifacts: OPENCODE_ARTIFACTS,
+        doctor_note: None,
+    },
+    AgentTool {
+        id: "qoder",
+        display_name: "Qoder",
+        artifacts: QODER_ARTIFACTS,
+        doctor_note: None,
+    },
+    AgentTool {
+        id: "codex",
+        display_name: "Codex",
+        artifacts: CODEX_ARTIFACTS,
+        doctor_note: Some("AGENTS.md provides Codex repo context"),
+    },
+];
+
+pub const AGENT_TOOL_IDS: &[&str] = &[
+    "claude", "cursor", "windsurf", "cline", "opencode", "qoder", "codex",
+];
+
+pub const AGENT_TOOL_LIST: &str = "claude, cursor, windsurf, cline, opencode, qoder, codex";
+pub const AGENT_TOOL_NAMES: &str = "Claude, Cursor, Windsurf, Cline, OpenCode, Qoder, Codex";
+
+pub fn agent_tool(id: &str) -> Option<&'static AgentTool> {
+    SUPPORTED_AGENT_TOOLS.iter().find(|tool| tool.id == id)
+}
+
+pub fn validate_agent_tools(tools: &[String]) -> anyhow::Result<()> {
+    let unsupported: Vec<&str> = tools
+        .iter()
+        .map(String::as_str)
+        .filter(|tool| agent_tool(tool).is_none())
+        .collect();
+
+    ensure!(
+        unsupported.is_empty(),
+        "Unsupported agent tool(s): {}. Supported values: {}",
+        unsupported.join(", "),
+        AGENT_TOOL_LIST
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AGENT_TOOL_IDS, SUPPORTED_AGENT_TOOLS, agent_tool, validate_agent_tools};
+
+    #[test]
+    fn supported_ids_match_tool_table() {
+        let ids: Vec<&str> = SUPPORTED_AGENT_TOOLS.iter().map(|tool| tool.id).collect();
+        assert_eq!(ids, AGENT_TOOL_IDS);
+    }
+
+    #[test]
+    fn codex_has_context_note_and_no_artifacts() {
+        let codex = agent_tool("codex").expect("codex should be supported");
+        assert!(codex.artifacts.is_empty());
+        assert_eq!(
+            codex.doctor_note,
+            Some("AGENTS.md provides Codex repo context")
+        );
+    }
+
+    #[test]
+    fn validate_agent_tools_rejects_unknown_values() {
+        let err = validate_agent_tools(&["codex".into(), "unknown".into()])
+            .expect_err("unknown tool should fail validation");
+
+        let message = err.to_string();
+        assert!(message.contains("unknown"));
+        assert!(message.contains("codex"));
+    }
+}

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,3 +1,4 @@
+use crate::agent_tools::validate_agent_tools;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -127,7 +128,7 @@ impl Default for CiConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentConfig {
-    /// AI tools to configure: claude, cursor, windsurf, cline, opencode
+    /// AI tools to configure: claude, cursor, windsurf, cline, opencode, qoder, codex
     #[serde(default = "default_agent_tools")]
     pub tools: Vec<String>,
 
@@ -265,6 +266,7 @@ impl HarnConfig {
     pub fn load(path: &Path) -> anyhow::Result<Self> {
         let content = std::fs::read_to_string(path)?;
         let config: Self = toml::from_str(&content)?;
+        config.validate()?;
         Ok(config)
     }
 
@@ -331,6 +333,14 @@ impl HarnConfig {
         }
         modules
     }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if let Some(agent) = &self.modules.agent {
+            validate_agent_tools(&agent.tools)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl Default for SddConfig {
@@ -339,5 +349,55 @@ impl Default for SddConfig {
             playbooks: true,
             reference: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HarnConfig;
+
+    #[test]
+    fn load_rejects_unknown_agent_tool() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let path = dir.path().join("harn.toml");
+        let content = r#"
+[project]
+name = "bad-agent-tool"
+type = "single"
+
+[modules.agent]
+tools = ["codex", "unknown"]
+"#;
+        std::fs::write(&path, content).expect("config should be written");
+
+        let err = HarnConfig::load(&path).expect_err("unknown tool should fail validation");
+        let message = err.to_string();
+
+        assert!(message.contains("Unsupported agent tool(s): unknown"));
+        assert!(message.contains("codex"));
+    }
+
+    #[test]
+    fn load_accepts_supported_agent_tools() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let path = dir.path().join("harn.toml");
+        let content = r#"
+[project]
+name = "supported-agent-tool"
+type = "single"
+
+[modules.agent]
+tools = ["claude", "codex", "opencode"]
+commands = ["review"]
+"#;
+        std::fs::write(&path, content).expect("config should be written");
+
+        let config = HarnConfig::load(&path).expect("supported tools should load");
+        let agent = config
+            .modules
+            .agent
+            .expect("agent config should be present after parsing");
+
+        assert_eq!(agent.tools, vec!["claude", "codex", "opencode"]);
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent_tools;
 pub mod config;
 pub mod context;
 pub mod date;
@@ -5,6 +6,7 @@ pub mod doctor;
 pub mod module;
 pub mod url;
 
+pub use agent_tools::{AGENT_TOOL_IDS, AGENT_TOOL_LIST, AGENT_TOOL_NAMES};
 pub use config::HarnConfig;
 pub use context::{ProjectContext, WriteStatus};
 pub use module::{Module, ModuleId};

--- a/crates/modules/src/agent.rs
+++ b/crates/modules/src/agent.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use harn_core::agent_tools::validate_agent_tools;
 use harn_core::context::{ProjectContext, WriteStatus};
 use harn_core::module::{Module, ModuleId};
 use harn_templates::TemplateEngine;
@@ -12,6 +13,7 @@ use harn_templates::TemplateEngine;
 /// - Cline: .clinerules
 /// - `OpenCode`: .opencode/commands/
 /// - Qoder: .qoder/rules/
+/// - Codex: AGENTS.md
 ///
 /// Also generates CLAUDE.md and AGENTS.md project context files.
 pub struct AgentModule;
@@ -26,7 +28,7 @@ impl Module for AgentModule {
     }
 
     fn description(&self) -> &str {
-        "AI coding agent configs (Claude, Cursor, Windsurf, Cline, OpenCode, Qoder)"
+        "AI coding agent configs (Claude, Cursor, Windsurf, Cline, OpenCode, Qoder, Codex)"
     }
 
     fn generate(&self, ctx: &mut ProjectContext) -> Result<Vec<(String, WriteStatus)>> {
@@ -36,6 +38,7 @@ impl Module for AgentModule {
         let mut files = Vec::new();
 
         let agent_config = ctx.config.modules.agent.clone().unwrap_or_default();
+        validate_agent_tools(&agent_config.tools)?;
 
         // Build slash commands table from configured commands
         let slash_table = Self::build_slash_commands_table(&agent_config.commands);
@@ -70,7 +73,8 @@ impl Module for AgentModule {
                 "qoder" => {
                     files.extend(self.generate_qoder(ctx, &engine, &vars)?);
                 }
-                _ => {} // Unknown tool, skip
+                "codex" => {}
+                _ => unreachable!("validate_agent_tools should reject unsupported tools"),
             }
         }
 

--- a/crates/modules/src/project_checks.rs
+++ b/crates/modules/src/project_checks.rs
@@ -1,3 +1,4 @@
+use harn_core::agent_tools::{AgentToolArtifact, agent_tool};
 use harn_core::config::HarnConfig;
 use harn_core::doctor::{CheckResult, Diagnostic, Severity};
 use std::path::Path;
@@ -47,20 +48,8 @@ pub fn check_agent(root: &Path, config: &HarnConfig) -> CheckResult {
         return result;
     };
 
-    // Check CLAUDE.md exists
-    if root.join("CLAUDE.md").exists() {
-        CheckResult::ok(check, "CLAUDE.md exists");
-    } else {
-        result.push(Diagnostic {
-            severity: Severity::Warning,
-            check: check.into(),
-            message: "CLAUDE.md missing".into(),
-            fix: None,
-        });
-    }
-
-    // Check AGENTS.md exists
-    if root.join("AGENTS.md").exists() {
+    let has_agents_md = root.join("AGENTS.md").exists();
+    if has_agents_md {
         CheckResult::ok(check, "AGENTS.md exists");
     } else {
         result.push(Diagnostic {
@@ -71,40 +60,83 @@ pub fn check_agent(root: &Path, config: &HarnConfig) -> CheckResult {
         });
     }
 
-    // Check tool-specific config files
-    for tool in &agent.tools {
-        let path = match tool.as_str() {
-            "claude" => ".claude/settings.json",
-            "cursor" => ".cursor/rules",
-            "windsurf" => ".windsurfrules",
-            "cline" => ".clinerules",
-            "qoder" => ".qoder/rules/harn.md",
-            _ => continue,
-        };
-
-        if root.join(path).exists() {
-            CheckResult::ok(check, format!("{path} exists ({tool})"));
+    let has_claude_md = root.join("CLAUDE.md").exists();
+    if agent.tools.iter().any(|tool| tool == "claude") {
+        if has_claude_md {
+            CheckResult::ok(check, "CLAUDE.md exists");
         } else {
             result.push(Diagnostic {
                 severity: Severity::Warning,
                 check: check.into(),
-                message: format!("{path} missing (tool: {tool})"),
+                message: "CLAUDE.md missing (tool: claude)".into(),
                 fix: None,
             });
         }
+    } else if has_claude_md {
+        CheckResult::ok(check, "CLAUDE.md exists (supplemental context)");
     }
 
-    // Check package manager consistency
-    if agent.tools.iter().any(|t| t == "claude") {
+    for tool_id in &agent.tools {
+        let Some(tool) = agent_tool(tool_id) else {
+            result.push(Diagnostic {
+                severity: Severity::Error,
+                check: check.into(),
+                message: format!("unsupported agent tool configured: {tool_id}"),
+                fix: None,
+            });
+            continue;
+        };
+
+        if let Some(note) = tool.doctor_note
+            && has_agents_md
+        {
+            CheckResult::ok(check, format!("{note} ({tool_id})"));
+        }
+
+        for artifact in tool.artifacts {
+            check_agent_artifact(
+                root,
+                *artifact,
+                tool_id,
+                &agent.commands,
+                &mut result,
+                check,
+            );
+        }
+    }
+
+    if agent.tools.iter().any(|tool| tool == "claude") {
         let settings_path = root.join(".claude/settings.json");
-        if settings_path.exists() {
-            if let Ok(content) = std::fs::read_to_string(&settings_path) {
-                check_package_manager_consistency(root, &content, &mut result, check);
-            }
+        if settings_path.exists()
+            && let Ok(content) = std::fs::read_to_string(&settings_path)
+        {
+            check_package_manager_consistency(root, &content, &mut result, check);
         }
     }
 
     result
+}
+
+fn check_agent_artifact(
+    root: &Path,
+    artifact: AgentToolArtifact,
+    tool_id: &str,
+    commands: &[String],
+    result: &mut CheckResult,
+    check: &str,
+) {
+    for path in artifact.expected_paths(commands) {
+        if root.join(&path).exists() {
+            CheckResult::ok(check, format!("{path} exists ({tool_id})"));
+        } else {
+            result.push(Diagnostic {
+                severity: Severity::Warning,
+                check: check.into(),
+                message: format!("{path} missing (tool: {tool_id})"),
+                fix: None,
+            });
+        }
+    }
 }
 
 fn check_package_manager_consistency(
@@ -413,4 +445,74 @@ pub fn run_all_project_checks(root: &Path, config: &HarnConfig) -> CheckResult {
     result.merge(check_quality(root, config));
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_agent;
+    use harn_core::config::{AgentConfig, HarnConfig, ModulesConfig, ProjectConfig, StacksConfig};
+
+    fn config_with_agent(tools: &[&str], commands: &[&str]) -> HarnConfig {
+        HarnConfig {
+            project: ProjectConfig {
+                name: "agent-checks".into(),
+                r#type: "single".into(),
+            },
+            stacks: StacksConfig::default(),
+            modules: ModulesConfig {
+                agent: Some(AgentConfig {
+                    tools: tools.iter().map(ToString::to_string).collect(),
+                    commands: commands.iter().map(ToString::to_string).collect(),
+                    ..AgentConfig::default()
+                }),
+                ..ModulesConfig::default()
+            },
+        }
+    }
+
+    #[test]
+    fn codex_passes_with_agents_md_only() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(dir.path().join("AGENTS.md"), "# Agent Context\n")
+            .expect("AGENTS.md should be written");
+
+        let result = check_agent(dir.path(), &config_with_agent(&["codex"], &[]));
+
+        assert_eq!(result.warning_count(), 0);
+        assert_eq!(result.error_count(), 0);
+    }
+
+    #[test]
+    fn opencode_checks_command_files() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(dir.path().join("AGENTS.md"), "# Agent Context\n")
+            .expect("AGENTS.md should be written");
+
+        let result = check_agent(dir.path(), &config_with_agent(&["opencode"], &["review"]));
+
+        assert_eq!(result.warning_count(), 1);
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diag| diag.message == ".opencode/commands/review.md missing (tool: opencode)")
+        );
+    }
+
+    #[test]
+    fn unknown_tool_is_reported_as_error() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(dir.path().join("AGENTS.md"), "# Agent Context\n")
+            .expect("AGENTS.md should be written");
+
+        let result = check_agent(dir.path(), &config_with_agent(&["unknown"], &[]));
+
+        assert_eq!(result.error_count(), 1);
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diag| diag.message == "unsupported agent tool configured: unknown")
+        );
+    }
 }

--- a/crates/modules/tests/template_coverage.rs
+++ b/crates/modules/tests/template_coverage.rs
@@ -1,3 +1,4 @@
+use harn_core::agent_tools::AGENT_TOOL_IDS;
 use harn_modules::sdd::SDD_PLAYBOOK_FILES;
 use harn_templates::TemplateEngine;
 
@@ -130,6 +131,20 @@ fn ci_templates_exist_for_all_providers() {
         assert!(
             engine.has_template(&path),
             "Missing CI template for {provider}: {path}"
+        );
+    }
+}
+
+/// Verify that README mentions every supported agent tool value.
+#[test]
+fn readme_mentions_supported_agent_tools() {
+    let readme =
+        std::fs::read_to_string("../../README.md").expect("Could not read repository README");
+
+    for tool in AGENT_TOOL_IDS {
+        assert!(
+            readme.contains(tool),
+            "README.md should mention supported agent tool '{tool}'"
         );
     }
 }

--- a/docs/playbooks/add-new-language.md
+++ b/docs/playbooks/add-new-language.md
@@ -73,7 +73,7 @@ No code changes needed — `docker.rs` auto-discovers `Dockerfile.<lang>`.
 
 Update these files:
 - `README.md` — Language Support table
-- `CLAUDE.md` — already references this playbook in Extension Points
+- `AGENTS.md` — already references this playbook in Extension Points
 
 ## Verification
 

--- a/docs/playbooks/coding-agent-workflow.md
+++ b/docs/playbooks/coding-agent-workflow.md
@@ -2,6 +2,8 @@
 
 Core principle: **Read docs first, write code, update docs last.**
 
+Use `AGENTS.md` as the primary repo brief; tool-specific files such as `CLAUDE.md` add workflow-specific overlays.
+
 ## Flow
 
 ```

--- a/templates/agent/AGENTS.md
+++ b/templates/agent/AGENTS.md
@@ -1,6 +1,16 @@
 # {{ project_name }} — Agent Context
 
-Universal context for AI coding agents. See CLAUDE.md for full reference.
+Primary repository context for Codex and other coding agents.
+
+## Overview
+
+_Brief project description._
+
+## Key Paths
+
+```
+TODO: List key directories and files
+```
 
 ## Commands
 
@@ -11,6 +21,14 @@ Universal context for AI coding agents. See CLAUDE.md for full reference.
 {{ build_tool }} fmt          # Format code
 {{ build_tool }} clean        # Clean artifacts
 ```
+
+## Slash Commands
+
+These are primarily used by Claude Code / OpenCode style workflows.
+
+| Command | Purpose |
+|---------|---------|
+{{ slash_commands_table }}
 
 ## Coding Rules
 
@@ -28,6 +46,7 @@ Universal context for AI coding agents. See CLAUDE.md for full reference.
 
 - Branches: `feat/xxx`, `fix/xxx`, `docs/xxx`, `refactor/xxx`
 - Pre-commit: `{{ build_tool }} lint && {{ build_tool }} test`
+- Tool-specific overlays live under `.claude/`, `.cursor/`, `.opencode/`, and similar paths
 
 ## SDD (Spec-Driven Development)
 

--- a/templates/agent/CLAUDE.md
+++ b/templates/agent/CLAUDE.md
@@ -1,14 +1,12 @@
-# {{ project_name }}
+# {{ project_name }} — Claude Code Context
 
-## Overview
+Read `AGENTS.md` first. This file adds Claude Code specific workflow details.
 
-_Brief project description._
+## Claude Files
 
-## Key Paths
-
-```
-TODO: List key directories and files
-```
+- `.claude/settings.json` — tool permissions and hooks
+- `.claude/commands/` — slash command implementations
+- `AGENTS.md` — repo-wide coding rules and project context
 
 ## Commands
 
@@ -28,31 +26,13 @@ TODO: List key directories and files
 
 ## Coding Rules
 
-1. **Lint before commit** — `{{ build_tool }} lint` must pass
-2. **Test before commit** — `{{ build_tool }} test` must pass
-{% if project_type == "api" or project_type == "service" %}
-3. **API envelope** — Standard response format
-4. **SSOT** — Types in `docs/reference/types/`
-{% endif %}
-5. **No hardcoded secrets** — Use env vars
-6. **Conventional commits** — `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
-{% if project_type == "api" or project_type == "service" %}
-7. **Doc sync** — Update reference docs when changing APIs/types/schema
-{% endif %}
+1. Use `AGENTS.md` as the repo-wide source of truth
+2. Keep `.claude/commands/` aligned with the slash command table below
+3. Review `.claude/settings.json` permissions before enabling broad shell access
+4. Run `{{ build_tool }} lint` and `{{ build_tool }} test` before shipping
 
-## Git Conventions
+## Workflow
 
-- Branches: `feat/xxx`, `fix/xxx`, `docs/xxx`, `refactor/xxx`
-- Pre-commit: `{{ build_tool }} lint && {{ build_tool }} test`
-
-## SDD (Spec-Driven Development)
-
-```
-Draft -> Active -> Completed
-```
-
-- Specs: `docs/specs/` (registry: `_index.md`)
-{% if project_type == "api" or project_type == "service" %}
-- Reference: `docs/reference/` (SSOT)
-{% endif %}
-- Playbooks: `docs/playbooks/`
+- Start from `AGENTS.md` for project structure, rules, and references
+- Use slash commands from `.claude/commands/` for Claude-specific workflows
+- Update `AGENTS.md` when the persistent project context changes

--- a/templates/agent/clinerules
+++ b/templates/agent/clinerules
@@ -17,3 +17,4 @@
 - Read files before editing — understand existing code first
 - Use `{{ build_tool }} check` to verify changes (lint + test)
 - Prefer editing existing files over creating new ones
+- Treat `AGENTS.md` as the primary project brief

--- a/templates/agent/cursor-rules
+++ b/templates/agent/cursor-rules
@@ -15,7 +15,7 @@
 
 ## File References
 
-@CLAUDE.md — Full project rules and commands
+@AGENTS.md — Primary project rules and context
 @docs/specs/_index.md — Spec registry
 {% if project_type == "api" or project_type == "service" %}
 @docs/reference/ — SSOT type definitions and API conventions

--- a/templates/agent/qoderrules
+++ b/templates/agent/qoderrules
@@ -15,6 +15,6 @@
 
 ## Key Paths
 
-- `CLAUDE.md` — Full project rules and commands
+- `AGENTS.md` — Primary project rules and context
 - `docs/specs/_index.md` — Spec registry
 - `docs/playbooks/` — Development playbooks

--- a/templates/agent/windsurfrules
+++ b/templates/agent/windsurfrules
@@ -15,7 +15,7 @@
 
 ## Key Paths
 
-- `CLAUDE.md` — Full project rules and commands
+- `AGENTS.md` — Primary project rules and context
 - `docs/specs/_index.md` — Spec registry
 - `docs/playbooks/` — Development playbooks
 {% if project_type == "api" or project_type == "service" %}

--- a/templates/sdd/playbooks/add-new-language.md
+++ b/templates/sdd/playbooks/add-new-language.md
@@ -73,7 +73,7 @@ No code changes needed — `docker.rs` auto-discovers `Dockerfile.<lang>`.
 
 Update these files:
 - `README.md` — Language Support table
-- `CLAUDE.md` — already references this playbook in Extension Points
+- `AGENTS.md` — already references this playbook in Extension Points
 
 ## Verification
 

--- a/templates/sdd/playbooks/coding-agent-workflow.md
+++ b/templates/sdd/playbooks/coding-agent-workflow.md
@@ -2,6 +2,8 @@
 
 Core principle: **Read docs first, write code, update docs last.**
 
+Use `AGENTS.md` as the primary repo brief; tool-specific files such as `CLAUDE.md` add workflow-specific overlays.
+
 ## Flow
 
 ```


### PR DESCRIPTION
## Summary

- add first-class `codex` support across config validation, interactive setup, generated docs, and README
- centralize supported agent tool metadata so CLI, generation, and doctor checks stay in sync
- extend `harn doctor` to validate all configured agent tools, including OpenCode command files, and fail fast on unsupported values
- promote `AGENTS.md` to the primary repo brief and keep `CLAUDE.md` as a Claude-specific overlay
- add regression tests for supported/unsupported agent tools and README coverage

Closes #29
Closes #30
Closes #32

## Test plan

- [x] `make lint`
- [x] `make test`
- [x] smoke check: `tools = ["codex"]` generates expected output and `harn doctor` reports Codex context coverage
- [x] smoke check: unsupported agent tool in `harn.toml` fails `harn init --config`
